### PR TITLE
Makefile update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ lambda:
 	@cp config.json build/config.json
 	@if [ ! -d build/node_modules ] ;then mkdir build/node_modules; fi
 	@cp -R node_modules/aws-sdk build/node_modules/
+	@cp -R node_modules/xmlbuilder build/node_modules/
+	@cp -R node_modules/sax build/node_modules/
+	@cp -R node_modules/xml2js build/node_modules/
 	@cp -R node_modules/es6-promise build/node_modules/
 	@cp -R node_modules/imagemagick build/node_modules/
 	@cp -R libs build/


### PR DESCRIPTION
Added additional libraries to export in the image. It does not work otherwise.
After `npm install` in installs aws library dependencies into the node_modules under the project root and if I don't export them to the image, it does not work.