### PR TITLE
include lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "aws-sdk": "^2.2.9",
     "es6-promise": "^3.0.2",
-    "imagemagick": "^0.1.3"
+    "imagemagick": "^0.1.3",
+    "lodash": "^4.6.1"
   },
   "devDependencies": {
     "chai": "^3.4.0",


### PR DESCRIPTION
I needed this change; otherwise I'd get this error:
`Unable to import module 'index': Error at Function.Module._resolveFilename (module.js:338:15) at Function.Module._load (module.js:280:25) at Module.require (module.js:364:17) at require (module.js:380:17) at Object.<anonymous> (/var/task/node_modules/xmlbuilder/lib/index.js:5:12) at Object.<anonymous> (/var/task/node_modules/xmlbuilder/lib/index.js:14:4) at Module._compile (module.js:456:26) at Object.Module._extensions..js (module.js:474:10) at Module.load (module.js:356:32) at Function.Module._load (module.js:312:12)`

Probably some version incompatibility, this is what I have on my host:
`$ nodejs -v
v5.8.0
`