### PR TITLE
Use native Promise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4.3"
 before_script:
-  - npm install
+  - "npm install"
 script:
   - "npm test"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ lambda:
 	@if [ -d node_modules/xmlbuilder ] ;then cp -R node_modules/xmlbuilder build/node_modules/; fi
 	@if [ -d node_modules/sax ] ;then cp -R node_modules/sax build/node_modules/; fi
 	@if [ -d node_modules/xml2js ] ;then cp -R node_modules/xml2js build/node_modules/; fi
-	@cp -R node_modules/es6-promise build/node_modules/
 	@cp -R node_modules/imagemagick build/node_modules/
 	@cp -R libs build/
 	@cp -R bin build/
@@ -24,7 +23,7 @@ test:
 
 configtest:
 	@./bin/configtest
-	
+
 
 clean:
 	@echo "clean up package files"

--- a/libs/ImageProcessor.js
+++ b/libs/ImageProcessor.js
@@ -1,7 +1,6 @@
 var ImageResizer = require("./ImageResizer");
 var ImageReducer = require("./ImageReducer");
 var S3           = require("./S3");
-var Promise      = require("es6-promise").Promise;
 
 /**
  * Image processor

--- a/libs/ImageReducer.js
+++ b/libs/ImageReducer.js
@@ -5,8 +5,6 @@ var Pngout         = require("./optimizers/Pngout");
 var ReadableStream = require("./ReadableImageStream");
 var StreamChain    = require("./StreamChain");
 
-var Promise = require("es6-promise").Promise;
-
 /**
  * Image Reducer
  * Accept png/jpeg typed image

--- a/libs/ImageResizer.js
+++ b/libs/ImageResizer.js
@@ -1,6 +1,5 @@
 var ImageData   = require("./ImageData");
 
-var Promise     = require("es6-promise").Promise;
 var ImageMagick = require("imagemagick");
 
 /**

--- a/libs/S3.js
+++ b/libs/S3.js
@@ -1,7 +1,6 @@
 var ImageData = require("./ImageData");
 
 var aws     = require("aws-sdk");
-var Promise = require("es6-promise").Promise;
 var client  = new aws.S3({apiVersion: "2006-03-01"});
 
 /**
@@ -80,6 +79,3 @@ module.exports = {
     putObject: putObject,
     putObjects: putObjects
 };
-
-
-

--- a/libs/StreamChain.js
+++ b/libs/StreamChain.js
@@ -1,5 +1,4 @@
 var WritableStream = require("./WritableImageStream");
-var Promise        = require("es6-promise").Promise;
 
 /**
  * Strem Chain

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   ],
   "author": "Yoshiaki Sugimoto",
   "license": "MIT",
+  "engines": {
+    "node": ">=4.3.0"
+  },
   "dependencies": {
     "aws-sdk": "^2.2.9",
-    "es6-promise": "^3.0.2",
     "imagemagick": "^0.1.3"
   },
   "devDependencies": {

--- a/tests/e2e-jpeg.test.js
+++ b/tests/e2e-jpeg.test.js
@@ -1,7 +1,6 @@
 var ImageProcessor = require("../libs/ImageProcessor");
 var ImageData      = require("../libs/ImageData");
 var Config         = require("../libs/Config");
-var Promise        = require("es6-promise").Promise;
 var S3             = require("../libs/S3");
 
 var sinon      = require("sinon");

--- a/tests/e2e-png.test.js
+++ b/tests/e2e-png.test.js
@@ -1,7 +1,6 @@
 var ImageProcessor = require("../libs/ImageProcessor");
 var ImageData      = require("../libs/ImageData");
 var Config         = require("../libs/Config");
-var Promise        = require("es6-promise").Promise;
 var S3             = require("../libs/S3");
 
 var sinon      = require("sinon");


### PR DESCRIPTION
Now AWS Lambda Supports Node.js 4.3
https://aws.amazon.com/jp/about-aws/whats-new/2016/04/aws-lambda-supports-node-js-4-3/

---

**CAUTION** This PR is breaking and require our some decision to support for Node.js `v0.10` and `v4.3` before merging.

Can anyone update their Node.js version on AWS Lambda easily? If not so, we have to tag the current rev on master branch (before merging).

And should prompt users to install this individually to fir their Node.js version such as following...

```sh
# For users who update Node.js to v4.3:
git clone git@github.com:ysugimoto/aws-lambda-image.git
```

```sh
# For users who use Node.js v0.10:
git clone -b [tagname-supporting-v0.10] git@github.com:ysugimoto/aws-lambda-image.git
```