### PR TITLE
Handle symbols in image names

### DIFF
--- a/libs/ImageProcessor.js
+++ b/libs/ImageProcessor.js
@@ -36,7 +36,7 @@ ImageProcessor.prototype.run = function ImageProcessor_run(config) {
 
         S3.getObject(
             this.s3Object.bucket.name,
-            this.s3Object.object.key
+            unescape(this.s3Object.object.key.replace(/\+/g, ' '))
         )
         .then(function(imageData) {
             this.processImage(imageData, config)


### PR DESCRIPTION
S3 events encode filenames both with URL encoding and by replacing spaces with plus signs. For example, `A file+name` is passed to Lambda as `A+file%2Bname`. However, S3 expects the original filename as the key. This causes aws-lambda-image to fail on images that have spaces or symbols in them.