### PR TITLE
Switch to gm, enable cropping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ Configuration is simple, see below:
 - `resizes`: [Array] Resize setting.
   - `background`: [String] Background color to use for transparent pixels when destination image doesn't support transparency.
   - `bucket`: [Object] Destination bucket to override. If not supplied, it will use `bucket` setting.
-  - `crop`: [String] Dimensions to crop the image. [See ImageMagick crop documentation](http://imagemagick.org/script/command-line-options.php#crop)
+  - `crop`: [String] Dimensions to crop the image. [See ImageMagick crop documentation](http://imagemagick.org/script/command-line-options.php#crop).
   - `directory`: [String] Image directory path.
   - `format`: [String] Image format override. If not supplied, it will leave the image in original format.
-  - `gravity`: [String] Changes how `size` and `crop`. [See ImageMagick gravity documentation](http://imagemagick.org/script/command-line-options.php#gravity)
+  - `gravity`: [String] Changes how `size` and `crop`. [See ImageMagick gravity documentation](http://imagemagick.org/script/command-line-options.php#gravity).
   - `quality`: [Number] Determine reduced image quality ( enables only `JPG` ).
-  - `size`: [String] Image dimensions. [See ImageMagick geometry formats](http://imagemagick.org/script/command-line-processing.php#geometry)
+  - `size`: [String] Image dimensions. [See ImageMagick geometry documentation](http://imagemagick.org/script/command-line-processing.php#geometry).
 
 If you want to check how this works with your configuration, you can use `configtest`:
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,21 @@ Configuration is simple, see below:
       "directory": "resized/small"
     },
     {
+      "size": "600x600^",
+      "gravity": "Center",
+      "crop": "600x600",
+      "directory": "resized/cropped-to-square"
+    },
+    {
       "size": 600,
-      "directory": "resized/middle"
+      "directory": "resized/600-jpeg",
+      "format": "jpg",
+      "background": "white"
     },
     {
       "size": 900,
-      "directory": "resized/large"
+      "directory": "resized/large",
+      "quality": 90
     }
   ]
 }
@@ -71,10 +80,14 @@ Configuration is simple, see below:
   - `bucket`: [Object] Destination bucket to override. If not supplied, it will use `bucket` setting.
   - `quality`: [Number] Determine reduced image quality ( enables only `JPG` ).
 - `resizes`: [Array] Resize setting.
-  - `size`: [Number] Image width.
-  - `directory`: [String] Image directory path.
+  - `background`: [String] Background color to use for transparent pixels when destination image doesn't support transparency.
   - `bucket`: [Object] Destination bucket to override. If not supplied, it will use `bucket` setting.
+  - `crop`: [String] Dimensions to crop the image. [See ImageMagick crop documentation](http://imagemagick.org/script/command-line-options.php#crop)
+  - `directory`: [String] Image directory path.
+  - `format`: [String] Image format override. If not supplied, it will leave the image in original format.
+  - `gravity`: [String] Changes how `size` and `crop`. [See ImageMagick gravity documentation](http://imagemagick.org/script/command-line-options.php#gravity)
   - `quality`: [Number] Determine reduced image quality ( enables only `JPG` ).
+  - `size`: [String] Image dimensions. [See ImageMagick geometry formats](http://imagemagick.org/script/command-line-processing.php#geometry)
 
 If you want to check how this works with your configuration, you can use `configtest`:
 

--- a/config.json.sample
+++ b/config.json.sample
@@ -10,8 +10,10 @@
       "directory": "resized/small"
     },
     {
-      "size": 600,
-      "directory": "resized/middle"
+      "size": "600x600^",
+      "gravity": "Center",
+      "crop": "600x600",
+      "directory": "resized/cropped-to-square"
     },
     {
       "size": 900,

--- a/config.json.sample
+++ b/config.json.sample
@@ -13,8 +13,13 @@
       "size": "600x600^",
       "gravity": "Center",
       "crop": "600x600",
-      "format": "jpg",
       "directory": "resized/cropped-to-square"
+    },
+    {
+      "size": 600,
+      "directory": "resized/600-jpeg",
+      "format": "jpg",
+      "background": "white"
     },
     {
       "size": 900,

--- a/config.json.sample
+++ b/config.json.sample
@@ -13,6 +13,7 @@
       "size": "600x600^",
       "gravity": "Center",
       "crop": "600x600",
+      "format": "jpg",
       "directory": "resized/cropped-to-square"
     },
     {

--- a/index.js
+++ b/index.js
@@ -22,16 +22,17 @@ exports.handler = (event, context) => {
     );
 
     processor.run(config)
-    .then((proceedImages) => {
-        console.log("OK, numbers of " + proceedImages.length + " images has proceeded.");
-        context.succeed("OK, numbers of " + proceedImages.length + " images has proceeded.");
+    .then((processedImages) => {
+        var message = "OK, " + processedImages.length + " images were processed.";
+        console.log(message);
+        context.succeed(message);
     })
     .catch((messages) => {
         if ( messages === "Object was already processed." ) {
             console.log("Image already processed");
             context.succeed("Image already processed");
         } else {
-            context.fail("Woops, image process failed: " + messages);
+            context.fail("Error processing " + s3Object.object.key + ": " + messages);
         }
     });
 };

--- a/libs/ImageProcessor.js
+++ b/libs/ImageProcessor.js
@@ -25,11 +25,6 @@ class ImageProcessor {
      * @param Config config
      */
     run(config) {
-        // If object.size equals 0, stop process
-        if ( this.s3Object.object.size === 0 ) {
-            return Promise.reject("Object size equal zero. Nothing to process.");
-        }
-
         if ( ! config.get("bucket") ) {
             config.set("bucket", this.s3Object.bucket.name);
         }
@@ -53,8 +48,8 @@ class ImageProcessor {
     processImage(imageData, config) {
         const jpegOptimizer = config.get("jpegOptimizer", "mozjpeg");
         const promiseList   = config.get("resizes", []).filter((option) => {
-            option.size &&
-            imageData.fileName.indexOf(option.directory) !== 0 // don't process images in the output folder
+            return option.size &&
+                imageData.fileName.indexOf(option.directory) !== 0 // don't process images in the output folder
         }).map((option) => {
             if ( ! option.bucket ) {
                 option.bucket = config.get("bucket");

--- a/libs/ImageProcessor.js
+++ b/libs/ImageProcessor.js
@@ -104,7 +104,7 @@ class ImageProcessor {
     execReduceImage(option, imageData) {
         const reducer = new ImageReducer(option);
 
-        return reducer.exec(imageData)
+        return reducer.exec(imageData);
     }
 }
 

--- a/libs/ImageProcessor.js
+++ b/libs/ImageProcessor.js
@@ -63,11 +63,7 @@ class ImageProcessor {
      */
     processImage(imageData, config) {
         const jpegOptimizer = config.get("jpegOptimizer", "mozjpeg");
-        const promiseList   = config.get("resizes", []).filter((option) => {
-            return ( option.size   && option.size   > 0 ) ||
-                   ( option.width  && option.width  > 0 ) ||
-                   ( option.height && option.height > 0 );
-        }).map((option) => {
+        const promiseList   = config.get("resizes", []).filter((option) => option.size).map((option) => {
             if ( ! option.bucket ) {
                 option.bucket = config.get("bucket");
             }

--- a/libs/ImageProcessor.js
+++ b/libs/ImageProcessor.js
@@ -52,7 +52,10 @@ class ImageProcessor {
      */
     processImage(imageData, config) {
         const jpegOptimizer = config.get("jpegOptimizer", "mozjpeg");
-        const promiseList   = config.get("resizes", []).filter((option) => option.size).map((option) => {
+        const promiseList   = config.get("resizes", []).filter((option) => {
+            option.size &&
+            imageData.fileName.indexOf(option.directory) !== 0 // don't process images in the output folder
+        }).map((option) => {
             if ( ! option.bucket ) {
                 option.bucket = config.get("bucket");
             }

--- a/libs/ImageReducer.js
+++ b/libs/ImageReducer.js
@@ -32,28 +32,25 @@ class ImageReducer {
     exec(image) {
         const option = this.option;
 
-        return new Promise((resolve, reject) => {
-            const input   = new ReadableStream(image.data);
-            const streams = this.createReduceProcessList(image.type.toLowerCase());
-            const chain   = new StreamChain(input);
+        const input   = new ReadableStream(image.data);
+        const streams = this.createReduceProcessList(image.type.toLowerCase());
+        const chain   = new StreamChain(input);
 
-            chain.pipes(streams).run()
-            .then((buffer) => {
-                let dir = option.directory || image.dirName;
+        return chain.pipes(streams).run()
+        .then((buffer) => {
+            let dir = option.directory || image.dirName;
 
-                if ( dir ) {
-                    dir = dir.replace(/\/$/, "") + "/";
-                }
+            if ( dir ) {
+                dir = dir.replace(/\/$/, "") + "/";
+            }
 
-                resolve(new ImageData(
-                    dir + image.baseName,
-                    option.bucket || image.bucketName,
-                    buffer,
-                    image.headers,
-                    image.acl
-                ));
-            })
-            .catch((message) => reject(message));
+            return new ImageData(
+                dir + image.baseName,
+                option.bucket || image.bucketName,
+                buffer,
+                image.headers,
+                image.acl
+            );
         });
     };
 

--- a/libs/ImageResizer.js
+++ b/libs/ImageResizer.js
@@ -1,7 +1,9 @@
 "use strict";
 
 const ImageData   = require("./ImageData");
-const ImageMagick = require("imagemagick");
+const gm = require("gm").subClass({ imageMagick: true });
+
+const cropSpec = /(\d+)x(\d+)([+-]\d+)?([+-]\d+)?(%)?/;
 
 class ImageResizer {
 
@@ -24,34 +26,33 @@ class ImageResizer {
      * @return Promise
      */
     exec(image) {
-        const params = {
-            srcData:   image.data.toString("binary"),
-            srcFormat: image.type,
-            format:    image.type
-        };
-
         const acl = this.options.acl;
 
-        if ( "size" in this.options ) {
-            params.width = this.options.size;
-        } else {
-            if ( "width" in this.options ) {
-                params.width = this.options.width;
-            }
-            if ( "height" in this.options ) {
-                params.height = this.options.height;
-            }
-        }
+        const width = this.options.size || this.options.width;
+        const height = this.options.size || this.options.height;
 
         return new Promise((resolve, reject) => {
-            ImageMagick.resize(params, (err, stdout, stderr) => {
-                if ( err || stderr ) {
-                    reject("ImageMagick err" + (err || stderr));
+            var img = gm(image.data).geometry(this.options.size.toString());
+            if ( "gravity" in this.options ) {
+                img = img.gravity(this.options.gravity);
+            }
+            if ( "crop" in this.options ) {
+                var cropArgs = this.options.crop.match(cropSpec);
+                const cropWidth = cropArgs[1];
+                const cropHeight = cropArgs[2];
+                const cropX = cropArgs[3];
+                const cropY = cropArgs[4];
+                const cropPercent = cropArgs[5];
+                img = img.crop(cropWidth, cropHeight, cropX, cropY, cropPercent === "%");
+            }
+            img.toBuffer((err, buffer) => {
+                if (err) {
+                    reject(err);
                 } else {
                     resolve(new ImageData(
                         image.fileName,
                         image.bucketName,
-                        stdout,
+                        buffer,
                         image.headers,
                         acl
                     ));

--- a/libs/ImageResizer.js
+++ b/libs/ImageResizer.js
@@ -45,7 +45,8 @@ class ImageResizer {
                 const cropPercent = cropArgs[5];
                 img = img.crop(cropWidth, cropHeight, cropX, cropY, cropPercent === "%");
             }
-            img.toBuffer((err, buffer) => {
+
+            function toBufferHandler(err, buffer) {
                 if (err) {
                     reject(err);
                 } else {
@@ -57,7 +58,13 @@ class ImageResizer {
                         acl
                     ));
                 }
-            });
+            }
+
+            if ( "format" in this.options ) {
+              img.toBuffer(this.options.format, toBufferHandler);
+            } else {
+              img.toBuffer(toBufferHandler);
+            }
         });
     }
 }

--- a/libs/ImageResizer.js
+++ b/libs/ImageResizer.js
@@ -36,6 +36,9 @@ class ImageResizer {
             if ( "gravity" in this.options ) {
                 img = img.gravity(this.options.gravity);
             }
+            if ( "background" in this.options ) {
+              img = img.background(this.options.background).flatten();
+            }
             if ( "crop" in this.options ) {
                 var cropArgs = this.options.crop.match(cropSpec);
                 const cropWidth = cropArgs[1];

--- a/libs/ImageResizer.js
+++ b/libs/ImageResizer.js
@@ -61,9 +61,9 @@ class ImageResizer {
             }
 
             if ( "format" in this.options ) {
-              img.toBuffer(this.options.format, toBufferHandler);
+                img.toBuffer(this.options.format, toBufferHandler);
             } else {
-              img.toBuffer(toBufferHandler);
+                img.toBuffer(toBufferHandler);
             }
         });
     }

--- a/libs/ImageResizer.js
+++ b/libs/ImageResizer.js
@@ -28,9 +28,6 @@ class ImageResizer {
     exec(image) {
         const acl = this.options.acl;
 
-        const width = this.options.size || this.options.width;
-        const height = this.options.size || this.options.height;
-
         return new Promise((resolve, reject) => {
             var img = gm(image.data).geometry(this.options.size.toString());
             if ( "gravity" in this.options ) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "aws-sdk": "2.3.9",
-    "imagemagick": "^0.1.3",
+    "gm": "^1.23.0",
     "lodash": "4.12.0"
   },
   "devDependencies": {

--- a/tests/resize-gif.test.js
+++ b/tests/resize-gif.test.js
@@ -30,8 +30,7 @@ describe("Resize GIF Test", () => {
             });
         })
         .catch((err) => {
-            throw new Error(err);
-            done();
+            done(err);
         });
 
     });

--- a/tests/resize-gif.test.js
+++ b/tests/resize-gif.test.js
@@ -2,7 +2,7 @@
 
 const ImageResizer = require("../libs/ImageResizer");
 const ImageData    = require("../libs/ImageData");
-const ImageMagick  = require("imagemagick");
+const gm = require("gm").subClass({ imageMagick: true });
 
 const expect     = require("chai").expect;
 const fs         = require("fs");
@@ -19,11 +19,11 @@ describe("Resize GIF Test", () => {
         resizer.exec(image)
         .then((resized) => {
             fs.writeFileSync(destPath, resized.data, {encoding: "binary"});
-            ImageMagick.identify(["-format", "%w", destPath], (err, out) => {
+            gm(destPath).size((err, out) => {
                 if ( err ) {
                     expect.fail(err);
                 } else {
-                    expect(parseInt(out, 10)).to.equal(200);
+                    expect(out.width).to.equal(200);
                 }
                 fs.unlinkSync(destPath);
                 done();

--- a/tests/resize-jpeg.test.js
+++ b/tests/resize-jpeg.test.js
@@ -2,7 +2,7 @@
 
 const ImageResizer = require("../libs/ImageResizer");
 const ImageData    = require("../libs/ImageData");
-const ImageMagick  = require("imagemagick");
+const gm = require("gm").subClass({ imageMagick: true });
 
 const expect     = require("chai").expect;
 const fs         = require("fs");
@@ -19,11 +19,11 @@ describe("Resize JPEG Test", () => {
         resizer.exec(image)
         .then((resized) => {
             fs.writeFileSync(destPath, resized.data, {encoding: "binary"});
-            ImageMagick.identify(["-format", "%w", destPath], (err, out) => {
+            gm(destPath).size((err, out) => {
                 if ( err ) {
                     expect.fail(err);
                 } else {
-                    expect(parseInt(out, 10)).to.equal(200);
+                    expect(out.width).to.equal(200);
                 }
                 fs.unlinkSync(destPath);
                 done();
@@ -43,11 +43,11 @@ describe("Resize JPEG Test", () => {
         resizer.exec(image)
         .then((resized) => {
             fs.writeFileSync(destPath, resized.data, {encoding: "binary"});
-            ImageMagick.identify(["-format", "%w", destPath], (err, out) => {
+            gm(destPath).size((err, out) => {
                 if ( err ) {
                     expect.fail(err);
                 } else {
-                    expect(parseInt(out, 10)).to.equal(200);
+                    expect(out.width).to.equal(200);
                 }
                 fs.unlinkSync(destPath);
                 done();

--- a/tests/resize-jpeg.test.js
+++ b/tests/resize-jpeg.test.js
@@ -30,8 +30,7 @@ describe("Resize JPEG Test", () => {
             });
         })
         .catch((err) => {
-            throw new Error(err);
-            done();
+            done(err);
         });
 
     });
@@ -55,8 +54,7 @@ describe("Resize JPEG Test", () => {
             });
         })
         .catch((err) => {
-            throw new Error(err);
-            done();
+            done(err);
         });
 
     });

--- a/tests/resize-png.test.js
+++ b/tests/resize-png.test.js
@@ -2,7 +2,7 @@
 
 const ImageResizer = require("../libs/ImageResizer");
 const ImageData    = require("../libs/ImageData");
-const ImageMagick  = require("imagemagick");
+const gm = require("gm").subClass({ imageMagick: true });
 
 const expect     = require("chai").expect;
 const fs         = require("fs");
@@ -22,11 +22,11 @@ describe("Resize PNG Test", () => {
         resizer.exec(image)
         .then((resized) => {
             fs.writeFileSync(destPath, resized.data, {encoding: "binary"});
-            ImageMagick.identify(["-format", "%w", destPath], (err, out) => {
+            gm(destPath).size((err, out) => {
                 if ( err ) {
                     expect.fail();
                 } else {
-                    expect(parseInt(out, 10)).to.equal(200);
+                    expect(out.width).to.equal(200);
                 }
                 fs.unlinkSync(destPath);
                 done();

--- a/tests/resize-png.test.js
+++ b/tests/resize-png.test.js
@@ -32,9 +32,8 @@ describe("Resize PNG Test", () => {
                 done();
             });
         })
-        .catch((message) => {
-            throw new Error(message);
-            done();
+        .catch((err) => {
+            done(err);
         });
     });
 });

--- a/tests/resize-png.test.js
+++ b/tests/resize-png.test.js
@@ -36,4 +36,30 @@ describe("Resize PNG Test", () => {
             done(err);
         });
     });
+
+    it("Convert PNG to JPEG", (done) => {
+        const resizer = new ImageResizer({size: 200, format: "jpg"});
+        const image = new ImageData(
+            "fixture/fixture.png",
+            "fixture",
+            fs.readFileSync(path.join(__dirname, "/fixture/fixture.png"), {encoding: "binary"})
+        );
+
+        resizer.exec(image)
+        .then((resized) => {
+            fs.writeFileSync(destPath, resized.data, {encoding: "binary"});
+            gm(destPath).format((err, out) => {
+                if ( err ) {
+                    expect.fail();
+                } else {
+                    expect(out).to.equal("JPEG");
+                }
+                fs.unlinkSync(destPath);
+                done();
+            });
+        })
+        .catch((err) => {
+            done(err);
+        });
+    });
 });


### PR DESCRIPTION
Switches to the [`gm` module](https://github.com/aheckmann/gm) because the [`imagemagick` module](https://github.com/yourdeveloper/node-imagemagick) is unmaintained:

> Note: This code has been unmaintained for a long time. Please consider using the gm module instead.

I made the `size` configuration option  pass through directly to ImageMagick, so you can use all the [fancy geometry options](http://imagemagick.org/script/command-line-processing.php#geometry). Fix #37. Fix #56.

I also added in configuration options for `crop` and `gravity` so you can get a nice zoom-crop behavior that people often want for user-uploaded avatar images. Fix #38.

I also added in configuration options for `format` and `background` so you can force the destination image to be a specific format, and specify the background color if that format doesn't support transparency (PNG->JPG). Fix #45.