### PR TITLE
syncronous processing for lower memory usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ exports.handler = (event, context) => {
 
     processor.run(config)
     .then((processedImages) => {
-        var message = "OK, " + processedImages.length + " images were processed.";
+        var message = "OK, " + processedImages + " images were processed.";
         console.log(message);
         context.succeed(message);
     })

--- a/libs/ImageData.js
+++ b/libs/ImageData.js
@@ -102,6 +102,26 @@ class ImageData {
     get acl() {
         return this._acl;
     }
+
+    /**
+     * Combines dirName, filename, and directory (from options).
+     *
+     * @public
+     * @param String directory (from options)
+     * @return String
+     */
+    combineWithDirectory(directory) {
+        if ( directory != null ) {
+            // ./X , ../X , . , ..
+            if ( directory.match(/^\.\.?\//) || directory.match(/^\.\.?$/) ) {
+                return path.join(this.dirName, directory, this.baseName);
+            } else {
+                return path.join(directory, this.baseName);
+            }
+        } else {
+            return path.join(this.dirName, this.baseName);
+        }
+    }
 }
 
 module.exports = ImageData;

--- a/libs/ImageProcessor.js
+++ b/libs/ImageProcessor.js
@@ -34,8 +34,7 @@ class ImageProcessor {
             this.s3Object.bucket.name,
             decodeURIComponent(this.s3Object.object.key.replace(/\+/g, ' '))
         )
-        .then((imageData) => this.processImage(imageData, config))
-        .then(S3.putObjects);
+        .then((imageData) => this.processImage(imageData, config));
     }
 
     /**
@@ -48,19 +47,18 @@ class ImageProcessor {
      */
     processImage(imageData, config) {
         const jpegOptimizer = config.get("jpegOptimizer", "mozjpeg");
-        const promiseList   = config.get("resizes", []).filter((option) => {
-            return option.size &&
-                imageData.fileName.indexOf(option.directory) !== 0 // don't process images in the output folder
-        }).map((option) => {
-            if ( ! option.bucket ) {
-                option.bucket = config.get("bucket");
+        let promise = new Promise((resolve) => { resolve() });
+        let processedImages = 0;
+
+        if ( config.exists("backup") ) {
+            const backup = config.get("backup");
+
+            if ( ! backup.bucket ) {
+                backup.bucket = config.get("bucket");
             }
-            if ( ! option.acl ){
-                option.acl = config.get("acl");
-            }
-            option.jpegOptimizer = option.jpegOptimizer || jpegOptimizer;
-            return this.execResizeImage(option, imageData);
-        });
+            promise = promise.then(() => this.execBackupImage(backup, imageData).then(S3.putObject));
+            processedImages++;
+        }
 
         if ( config.exists("reduce") ) {
             const reduce = config.get("reduce");
@@ -69,19 +67,26 @@ class ImageProcessor {
                 reduce.bucket = config.get("bucket");
             }
             reduce.jpegOptimizer = reduce.jpegOptimizer || jpegOptimizer;
-            promiseList.unshift(this.execReduceImage(reduce, imageData));
+            promise = promise.then(() => this.execReduceImage(reduce, imageData).then(S3.putObject));
+            processedImages++;
         }
 
-        if ( config.exists("backup") ) {
-            const backup = config.get("backup");
-
-            if ( ! backup.bucket ) {
-                backup.bucket = config.get("bucket");
+        config.get("resizes", []).filter((option) => {
+            return option.size &&
+                imageData.fileName.indexOf(option.directory) !== 0 // don't process images in the output folder
+        }).forEach((option) => {
+            if ( ! option.bucket ) {
+                option.bucket = config.get("bucket");
             }
-            promiseList.unshift(this.execBackupImage(backup, imageData));
-        }
+            if ( ! option.acl ){
+                option.acl = config.get("acl");
+            }
+            option.jpegOptimizer = option.jpegOptimizer || jpegOptimizer;
+            promise = promise.then(() => this.execResizeImage(option, imageData).then(S3.putObject));
+            processedImages++;
+        });
 
-        return Promise.all(promiseList);
+        return promise.then(() => new Promise((resolve) => resolve(processedImages)));
     }
 
     /**
@@ -118,26 +123,12 @@ class ImageProcessor {
     }
 
     execBackupImage(option, image) {
-        let dir;
-
-        if ( option.directory ) {
-            if ( option.directory.match(/^\.\//) ) {
-                dir = image.dirName + "/" + option.directory.replace(/^\.\//, '') + "/";
-            } else {
-                dir = option.directory + "/" + image.dirName + "/";
-            }
-        } else {
-            dir = image.dirName + "/";
-        }
-
-        dir = dir.replace(/[\/]+/g, "/");
-
         return new Promise((resolve, reject) => {
             console.log("Backing up to: " + (option.directory || "in-place"));
 
             resolve(
                 new ImageData(
-                    dir + image.baseName,
+                    image.combineWithDirectory(option.directory),
                     option.bucket || image.bucketName,
                     image.data,
                     image.headers,

--- a/libs/ImageReducer.js
+++ b/libs/ImageReducer.js
@@ -38,22 +38,8 @@ class ImageReducer {
 
         return chain.pipes(streams).run()
         .then((buffer) => {
-            let dir;
-
-            if ( option.directory ) {
-                if ( option.directory.match(/^\.\//) ) {
-                    dir = image.dirName + "/" + option.directory.replace(/^\.\//, '') + "/";
-                } else {
-                    dir = option.directory + "/" + image.dirName + "/";
-                }
-            } else {
-                dir = image.dirName + "/";
-            }
-
-            dir = dir.replace(/[\/]+/g, "/");
-
             return new ImageData(
-                dir + image.baseName,
+                image.combineWithDirectory(option.directory),
                 option.bucket || image.bucketName,
                 buffer,
                 image.headers,

--- a/libs/S3.js
+++ b/libs/S3.js
@@ -46,19 +46,19 @@ class S3 {
      * @param Buffer buffer
      * @return Promise
      */
-    static putObject(bucket, key, buffer, headers, acl) {
+    static putObject(image) {
         return new Promise((resolve, reject) => {
             const params = {
-                Bucket:       bucket,
-                Key:          key,
-                Body:         buffer,
+                Bucket:       image.bucketName,
+                Key:          image.fileName,
+                Body:         image.data,
                 Metadata:     { "img-processed": "true" },
-                ContentType:  headers.ContentType,
-                CacheControl: headers.CacheControl
+                ContentType:  image.headers.ContentType,
+                CacheControl: image.headers.CacheControl
             };
 
-            if ( acl ) {
-                params.ACL = acl;
+            if ( image.acl ) {
+                params.ACL = image.acl;
             }
             console.log("Uploading to: " + params.Key + " (" + params.Body.length + " bytes)");
             client.putObject(params, (err) => {
@@ -76,7 +76,7 @@ class S3 {
     static putObjects(images) {
         return Promise.all(images.map((image) => {
             return new Promise((resolve, reject) => {
-                S3.putObject(image.bucketName, image.fileName, image.data, image.headers, image.acl)
+                S3.putObject(image)
                 .then(() => resolve(image))
                 .catch((message) => reject(message));
             });

--- a/tests/e2e-jpeg-jpegoptim.test.js
+++ b/tests/e2e-jpeg-jpegoptim.test.js
@@ -14,6 +14,7 @@ const setting    = JSON.parse(fs.readFileSync(sourceFile));
 
 describe("Optimize JPEG with JpegOptim Test", () => {
     let processor;
+    let images;
 
     before(() => {
         sinon.stub(S3, "getObject", () => {
@@ -31,16 +32,16 @@ describe("Optimize JPEG with JpegOptim Test", () => {
                 });
             });
         });
-        sinon.stub(S3, "putObjects", (images) => {
-            return Promise.all(images.map((image) => {
-                return image;
-            }));
+        images = [];
+        sinon.stub(S3, "putObject", (image) => {
+            images.push(image);
+            return new Promise((resolve) => resolve(image));
         });
     });
 
     after(() => {
         S3.getObject.restore();
-        S3.putObjects.restore();
+        S3.putObject.restore();
     });
 
     beforeEach(() => {
@@ -52,7 +53,7 @@ describe("Optimize JPEG with JpegOptim Test", () => {
 
     it("Reduce JPEG with no configuration", (done) => {
         processor.run(new Config({jpegOptimizer: "jpegoptim"}))
-        .then((images) => {
+        .then(() => {
             // no working
             expect(images).to.have.length(0);
             done();
@@ -64,7 +65,7 @@ describe("Optimize JPEG with JpegOptim Test", () => {
             jpegOptimizer: "jpegoptim",
             reduce: {}
         }))
-        .then((images) => {
+        .then(() => {
             expect(images).to.have.length(1);
             const image = images.shift();
             const buf = fs.readFileSync(path.join(__dirname, "/fixture/fixture.jpg"), {encoding: "binary"});
@@ -89,7 +90,7 @@ describe("Optimize JPEG with JpegOptim Test", () => {
                 "jpegOptimizer": "jpegoptim"
             }
         }))
-        .then((images) => {
+        .then(() => {
             expect(images).to.have.length(1);
             const image = images.shift();
             const buf = fs.readFileSync(path.join(__dirname, "/fixture/fixture.jpg"), {encoding: "binary"});

--- a/tests/e2e-jpeg.test.js
+++ b/tests/e2e-jpeg.test.js
@@ -14,6 +14,7 @@ const setting    = JSON.parse(fs.readFileSync(sourceFile));
 
 describe("Optimize JPEG Test", () => {
     let processor;
+    let images;
 
     before(() => {
         sinon.stub(S3, "getObject", () => {
@@ -31,16 +32,16 @@ describe("Optimize JPEG Test", () => {
                 });
             });
         });
-        sinon.stub(S3, "putObjects", (images) => {
-            return Promise.all(images.map((image) => {
-                return image;
-            }));
+        images = [];
+        sinon.stub(S3, "putObject", (image) => {
+            images.push(image);
+            return new Promise((resolve) => resolve(image));
         });
     });
 
     after(() => {
         S3.getObject.restore();
-        S3.putObjects.restore();
+        S3.putObject.restore();
     });
 
     beforeEach(() => {
@@ -52,7 +53,7 @@ describe("Optimize JPEG Test", () => {
 
     it("Reduce JPEG with no configuration", (done) => {
         processor.run(new Config({}))
-        .then((images) => {
+        .then(() => {
             // no working
             expect(images).to.have.length(0);
             done();
@@ -67,7 +68,7 @@ describe("Optimize JPEG Test", () => {
         processor.run(new Config({
             reduce: {}
         }))
-        .then((images) => {
+        .then(() => {
             expect(images).to.have.length(1);
             const image = images.shift();
             const buf = fs.readFileSync(path.join(__dirname, "/fixture/fixture.jpg"), {encoding: "binary"});
@@ -92,7 +93,7 @@ describe("Optimize JPEG Test", () => {
                 "directory": "some"
             }
         }))
-        .then((images) => {
+        .then(() => {
             expect(images).to.have.length(1);
             const image = images.shift();
             const buf = fs.readFileSync(path.join(__dirname, "/fixture/fixture.jpg"), {encoding: "binary"});

--- a/tests/e2e-png.test.js
+++ b/tests/e2e-png.test.js
@@ -14,6 +14,7 @@ const setting    = JSON.parse(fs.readFileSync(sourceFile));
 
 describe("Optimize PNG Test", () => {
     let processor;
+    let images;
 
     before(() => {
         sinon.stub(S3, "getObject", () => {
@@ -31,16 +32,16 @@ describe("Optimize PNG Test", () => {
                 });
             });
         });
-        sinon.stub(S3, "putObjects", (images) => {
-            return Promise.all(images.map((image) => {
-                return image;
-            }));
+        images = [];
+        sinon.stub(S3, "putObject", (image) => {
+            images.push(image);
+            return new Promise((resolve) => resolve(image));
         });
     });
 
     after(() => {
         S3.getObject.restore();
-        S3.putObjects.restore();
+        S3.putObject.restore();
     });
 
     beforeEach(() => {
@@ -52,7 +53,7 @@ describe("Optimize PNG Test", () => {
 
     it("Reduce PNG with no configuration", (done) => {
         processor.run(new Config({}))
-        .then((images) => {
+        .then(() => {
             // no working
             expect(images).to.have.length(0);
             done();
@@ -63,7 +64,7 @@ describe("Optimize PNG Test", () => {
         processor.run(new Config({
             reduce: {}
         }))
-        .then((images) => {
+        .then(() => {
             expect(images).to.have.length(1);
             const image = images.shift();
             const buf = fs.readFileSync(path.join(__dirname, "/fixture/fixture.png"), {encoding: "binary"});
@@ -87,7 +88,7 @@ describe("Optimize PNG Test", () => {
                 "directory": "resized"
             }
         }))
-        .then((images) => {
+        .then(() => {
             expect(images).to.have.length(1);
             const image = images.shift();
             const buf = fs.readFileSync(path.join(__dirname, "/fixture/fixture.png"), {encoding: "binary"});

--- a/tests/image-data.test.js
+++ b/tests/image-data.test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const ImageData  = require("../libs/ImageData");
+
+const expect     = require("chai").expect;
+
+describe("ImageData combineWithDirectory Test", () => {
+    let image = new ImageData("a/b/c/key.png", "bucket", "data", {});
+
+    it("No directory", () => {
+        expect(image.combineWithDirectory(undefined)).to.equal("a/b/c/key.png");
+    });
+
+    it("Empty directory", () => {
+        expect(image.combineWithDirectory("")).to.equal("key.png");
+    });
+
+    it("Relative directory", () => {
+        expect(image.combineWithDirectory("./d")).to.equal("a/b/c/d/key.png");
+    });
+
+    it("Internal directory", () => {
+        expect(image.combineWithDirectory("./d/e")).to.equal("a/b/c/d/e/key.png");
+    });
+
+    it("External directory", () => {
+        expect(image.combineWithDirectory("..")).to.equal("a/b/key.png");
+    });
+
+    it("External internal directory", () => {
+        expect(image.combineWithDirectory("../d")).to.equal("a/b/d/key.png");
+    });
+
+    it("Root directory", () => {
+        expect(image.combineWithDirectory("d")).to.equal("d/key.png");
+    });
+
+    it("Root internal directory", () => {
+        expect(image.combineWithDirectory("d/e")).to.equal("d/e/key.png");
+    });
+});


### PR DESCRIPTION
Current implementation processes all the files, keeps the buffers in memory, then uploads them.

New implementation processes first file, uploads, then moves on the the next file hopefully allowing the GC to collect.

With a 2MB image, 4 resizes, reduce and backup configured, this takes about 200ms more on average (9000ms -> 11000) but more than half the memory (450MB -> 150MB), thus saving some $.