### PR TITLE
Allow options to specify ACL of reduced image

### DIFF
--- a/libs/ImageProcessor.js
+++ b/libs/ImageProcessor.js
@@ -66,6 +66,11 @@ class ImageProcessor {
             if ( ! reduce.bucket ) {
                 reduce.bucket = config.get("bucket");
             }
+
+            if ( ! reduce.acl ) {
+                reduce.acl = config.get("acl");
+            }
+
             reduce.jpegOptimizer = reduce.jpegOptimizer || jpegOptimizer;
             promise = promise.then(() => this.execReduceImage(reduce, imageData).then(S3.putObject));
             processedImages++;

--- a/libs/ImageReducer.js
+++ b/libs/ImageReducer.js
@@ -43,7 +43,7 @@ class ImageReducer {
                 option.bucket || image.bucketName,
                 buffer,
                 image.headers,
-                image.acl
+                option.acl
             );
         });
     };


### PR DESCRIPTION
In the current implementation, it's not possible to specify the ACL of the image about to be reduced.  Instead, the ACL from the original image is read, which is not always desired and could have unexpected results.  This commit uses the ACL from the config and will use the generally specified ACL if none is available in the `reduce` object.