### PR TITLE
Allow setting custom policies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ coverage/
 test/
 claudia.json
 config.json.sample
+policies

--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,3 @@ coverage/
 test/
 claudia.json
 config.json.sample
-policies

--- a/README.md
+++ b/README.md
@@ -129,11 +129,37 @@ $ npm config set aws-lambda-image:timeout 5
 
 #### Deployment
 
-Command below will install the Lambda function on AWS, together with setting up proper role and privileges.
+Command below will deploy the Lambda function on AWS, together with setting up roles and policies.
 
 ```bash
 $ npm run deploy
 ```
+
+*Notice*: Because there are some limitations in `Claudia.js` support for policies, which could lead to issues
+with `Access Denied` when processing images from one bucket and saving them to another, we have decided to introduce support
+for custom policies.
+
+##### Custom policies
+
+Policies which should be installed together with our Lambda function are stored in `policies/` directory. We keep there
+policy that grants access to all buckets, which is preventing possible errors with `Access Denied` described above. If you
+have any security-related concerns, feel free to change the:
+
+```json
+"Resource": [
+    "*"
+]
+```
+
+in the `policies/s3-bucket-full-access.json` to something more restrictive, like:
+
+```json
+"Resource": [
+    "arn:aws:s3:::destination-bucket-name/*"
+]
+```
+
+Just keep in mind, that you need to make those changes before you do the deployment.
 
 #### Adding S3 event handlers
 
@@ -141,7 +167,7 @@ To complete installation process you will need to take one more action. It will 
 which will send information about all uploaded images directly to your Lambda function.
 
 ```bash
-$ npm run add-handler --s3_bucket="your-bucket-name" --s3_prefix="directory/" --s3_suffix=".jpg"
+$ npm run add-s3-handler --s3_bucket="your-bucket-name" --s3_prefix="directory/" --s3_suffix=".jpg"
 ```
 
 *Note:* Unfortunately, for now `Clauda.js` is able to install only one such handler per Bucket. This [issue](https://github.com/claudiajs/claudia/issues/101)

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   },
   "scripts": {
     "postinstall": "[ -f config.json ] || cp config.json.sample config.json",
-    "deploy": "claudia create --profile $npm_package_config_profile --region $npm_package_config_region --version dev --handler index.handler --no-optional-dependencies --timeout $npm_package_config_timeout --memory $npm_package_config_memory",
-    "add-handler": "claudia add-s3-event-source --profile $npm_package_config_profile --bucket $npm_config_s3_bucket --events s3:ObjectCreated:* --prefix $npm_config_s3_prefix --suffix $npm_config_s3_suffix",
+    "deploy": "claudia create --profile $npm_package_config_profile --region $npm_package_config_region --version dev --handler index.handler --no-optional-dependencies --timeout $npm_package_config_timeout --memory $npm_package_config_memory --policies policies/*.json",
+    "add-handler": "npm run add-s3-handler",
+    "add-s3-handler": "claudia add-s3-event-source --profile $npm_package_config_profile --bucket $npm_config_s3_bucket --events s3:ObjectCreated:* --prefix $npm_config_s3_prefix --suffix $npm_config_s3_suffix",
     "release": "claudia set-version --profile $npm_package_config_profile --version production",
     "update": "claudia update --profile $npm_package_config_profile --no-optional-dependencies",
     "test": "nyc ava",
@@ -37,6 +38,7 @@
     },
     {
       "name": "Kamil Dybicz",
+      "email": "kamil.dybicz@gmail.com",
       "web": "https://github.com/kdybicz"
     }
   ],

--- a/policies/s3-bucket-full-access.json
+++ b/policies/s3-bucket-full-access.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
At the moment there are some limitations in `Claudia`'s support for policies. When we're adding event handler for S3 bucket, `Claudia` sets policy that grant access only to that one bucket. As this could lead to problems with `Access Denied` when processed files are sent to different bucket, I've decide to add support for custom policies. From now on while deploying Lambda `Claudia` will read content of `policies/` directory in search for custom policies that should be installed together with our code. This allow users to add their own policies, also it will allows us to add policy that will grant access to all buckets by default - but users will be able to change that if needed. All is described in the documentation.