### PR TITLE
Upgrading dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,16 +45,16 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "2.6.15",
+    "aws-sdk": "^2.24.0",
     "gm": "^1.23.0",
-    "image-type": "2.1.0"
+    "image-type": "^3.0.0"
   },
   "devDependencies": {
     "ava": "^0.18.2",
     "aws-sdk-mock": "^1.6.1",
     "bind-all": "^1.0.0",
     "claudia": "^2.9.0",
-    "coveralls": "^2.11.15",
+    "coveralls": "^2.12.0",
     "nyc": "^10.1.2",
     "pify": "^2.3.0",
     "sinon": "^1.17.7"


### PR DESCRIPTION
Upgrading dependencies
* aws-sdk: 2.24.0
* image-type: 3.0.0
* coveralls: 2.12.0