### PR TITLE
restore old Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: clean configtest
+
+lambda:
+	npm install .
+	@echo "Factory package files..."
+	@if [ ! -d build ] ;then mkdir build; fi
+	@cp index.js build/index.js
+	@cp config.json build/config.json
+	@if [ -d build/node_modules ] ;then rm -rf build/node_modules; fi
+	@cp -R node_modules build/node_modules
+	@cp -R lib build/
+	@cp -R bin build/
+	@rm -rf build/bin/darwin
+	@echo "Create package archive..."
+	@cd build && zip -rq aws-lambda-image.zip .
+	@mv build/aws-lambda-image.zip ./
+
+uploadlambda: lambda
+	@if [ -z "${LAMBDA_FUNCTION_NAME}" ]; then (echo "Please export LAMBDA_FUNCTION_NAME" && exit 1); fi
+	aws lambda update-function-code --function-name ${LAMBDA_FUNCTION_NAME} --zip-file fileb://aws-lambda-image.zip
+
+configtest:
+	@./bin/configtest
+
+clean:
+	@echo "clean up package files"
+	@if [ -f aws-lambda-image.zip ]; then rm aws-lambda-image.zip; fi
+	@rm -rf build/*


### PR DESCRIPTION
For people who want to manually create their lambda function (like me).

The npm scripts do way more than I need - I want to configure my own roles and choose my own name for the lambda function, until it's possible with the npm scripts the `Makefile` should be kept.