### PR TITLE
Add move option in backup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 **/*{.,-}min.js
+node_modules/**/*.js
+build/**/*.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 **/*{.,-}min.js
 node_modules/**/*.js
-build/**/*.js

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ It's copy of our example file `config.json.sample`. More or less it looks like:
 |               |      prefix     |  String | Prepend filename prefix if supplied.                                                                                                      |
 |               |      suffix     |  String | Append filename suffix if supplied.                                                                                                       |
 |               |       acl       |  String | Permission of S3 object. [See AWS ACL documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property).  |
+|               |       move      | Boolean | If true, an original uploaded file will delete from Bucket after completion.                                                              |
 |    reduce     |        -        |  Object | Reduce setting following fields.                                                                                                          |
 |               |     quality     |  Number | Determine reduced image quality ( only `JPG` ).                                                                                           |
 |               |  jpegOptimizer  |  String | Determine optimiser that should be used `mozjpeg` (default) or `jpegoptim` ( only `JPG` ).                                                |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ It's copy of our example file `config.json.sample`. More or less it looks like:
 |               |      prefix     |  String | Prepend filename prefix if supplied.                                                                                                      |
 |               |      suffix     |  String | Append filename suffix if supplied.                                                                                                       |
 |               |       acl       |  String | Permission of S3 object. [See AWS ACL documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property).  |
-|               |       move      | Boolean | If true, an original uploaded file will delete from Bucket after completion.                                                              |
+|               |       move      | Boolean | If `true`, an original uploaded file will delete from Bucket after completion.                                                              |
 |    reduce     |        -        |  Object | Reduce setting following fields.                                                                                                          |
 |               |     quality     |  Number | Determine reduced image quality ( only `JPG` ).                                                                                           |
 |               |  jpegOptimizer  |  String | Determine optimiser that should be used `mozjpeg` (default) or `jpegoptim` ( only `JPG` ).                                                |

--- a/lib/ImageProcessor.js
+++ b/lib/ImageProcessor.js
@@ -50,22 +50,24 @@ class ImageProcessor {
         const acl = config.get("acl");
         const bucket = config.get("bucket");
         const jpegOptimizer = config.get("jpegOptimizer", "mozjpeg");
+        const removeAfterSuccess = ( config.get("backup", {}).move === true );
 
         let promise = Promise.resolve();
         let processedImages = 0;
-        let removeAfterSuccess = false;
 
         if ( config.exists("backup") ) {
             const backup = config.get("backup");
             backup.acl = backup.acl || acl;
             backup.bucket = backup.bucket || bucket;
-            // If backup.move option is true, remove original object after completion
-            removeAfterSuccess = Boolean(backup.move);
 
             promise = promise
               .then(() => this.execBackupImage(backup, imageData))
               .then((image) => this.fileSystem.putObject(image))
-              .then(() => Promise.resolve(++processedImages));
+              .then(() => {
+                console.log("backup success");
+                ++processedImages;
+                return Promise.resolve();
+              })
         }
 
         if ( config.exists("reduce") ) {
@@ -96,7 +98,8 @@ class ImageProcessor {
 
         if ( removeAfterSuccess ) {
           promise = promise
-            .then(() => this.fileSystem.deleteObject(imageData));
+            .then(() => this.fileSystem.deleteObject(imageData))
+            .then(() => Promise.resolve(processedImages));
         }
 
         return promise;

--- a/lib/ImageProcessor.js
+++ b/lib/ImageProcessor.js
@@ -59,8 +59,6 @@ class ImageProcessor {
             backup.acl = backup.acl || acl;
             backup.bucket = backup.bucket || bucket;
 
-              })
-
             promise = promise
               .then(() => this.execBackupImage(backup, imageData))
               .then((image) => this.fileSystem.putObject(image))

--- a/lib/ImageProcessor.js
+++ b/lib/ImageProcessor.js
@@ -51,18 +51,21 @@ class ImageProcessor {
         const bucket = config.get("bucket");
         const jpegOptimizer = config.get("jpegOptimizer", "mozjpeg");
 
-        let promise = new Promise((resolve) => { resolve(); });
+        let promise = Promise.resolve();
         let processedImages = 0;
+        let removeAfterSuccess = false;
 
         if ( config.exists("backup") ) {
             const backup = config.get("backup");
             backup.acl = backup.acl || acl;
             backup.bucket = backup.bucket || bucket;
+            // If backup.move option is true, remove original object after completion
+            removeAfterSuccess = Boolean(backup.move);
 
-            promise = promise.then(() => this.execBackupImage(backup, imageData).then((image) => {
-                this.fileSystem.putObject(image);
-            }));
-            processedImages++;
+            promise = promise
+              .then(() => this.execBackupImage(backup, imageData))
+              .then((image) => this.fileSystem.putObject(image))
+              .then(() => Promise.resolve(++processedImages));
         }
 
         if ( config.exists("reduce") ) {
@@ -71,10 +74,10 @@ class ImageProcessor {
             reduce.bucket = reduce.bucket || bucket;
             reduce.jpegOptimizer = reduce.jpegOptimizer || jpegOptimizer;
 
-            promise = promise.then(() => this.execReduceImage(reduce, imageData).then((image) => {
-                this.fileSystem.putObject(image);
-            }));
-            processedImages++;
+            promise = promise
+              .then(() => this.execReduceImage(reduce, imageData))
+              .then((image) => this.fileSystem.putObject(image))
+              .then(() => Promise.resolve(++processedImages));
         }
 
         config.get("resizes", []).filter((resize) => {
@@ -85,13 +88,18 @@ class ImageProcessor {
             resize.bucket = resize.bucket || bucket;
             resize.jpegOptimizer = resize.jpegOptimizer || jpegOptimizer;
 
-            promise = promise.then(() => this.execResizeImage(resize, imageData).then((image) => {
-                this.fileSystem.putObject(image);
-            }));
-            processedImages++;
+            promise = promise
+              .then(() => this.execResizeImage(resize, imageData))
+              .then((image) => this.fileSystem.putObject(image))
+              .then(() => Promise.resolve(++processedImages));
         });
 
-        return promise.then(() => new Promise((resolve) => resolve(processedImages)));
+        if ( removeAfterSuccess ) {
+          promise = promise
+            .then(() => this.fileSystem.deleteObject(imageData));
+        }
+
+        return promise;
     }
 
     /**

--- a/lib/ImageProcessor.js
+++ b/lib/ImageProcessor.js
@@ -50,7 +50,6 @@ class ImageProcessor {
         const acl = config.get("acl");
         const bucket = config.get("bucket");
         const jpegOptimizer = config.get("jpegOptimizer", "mozjpeg");
-        const removeAfterSuccess = ( config.get("backup", {}).move === true );
 
         let promise = Promise.resolve();
         let processedImages = 0;
@@ -60,14 +59,13 @@ class ImageProcessor {
             backup.acl = backup.acl || acl;
             backup.bucket = backup.bucket || bucket;
 
+              })
+
             promise = promise
               .then(() => this.execBackupImage(backup, imageData))
               .then((image) => this.fileSystem.putObject(image))
-              .then(() => {
-                console.log("backup success");
-                ++processedImages;
-                return Promise.resolve();
-              })
+              .then(() => ( backup.move === true ) ? this.fileSystem.deleteObject(imageData) : Promise.resolve())
+              .then(() => Promise.resolve(++processedImages));
         }
 
         if ( config.exists("reduce") ) {
@@ -95,12 +93,6 @@ class ImageProcessor {
               .then((image) => this.fileSystem.putObject(image))
               .then(() => Promise.resolve(++processedImages));
         });
-
-        if ( removeAfterSuccess ) {
-          promise = promise
-            .then(() => this.fileSystem.deleteObject(imageData))
-            .then(() => Promise.resolve(processedImages));
-        }
 
         return promise;
     }

--- a/lib/S3FileSystem.js
+++ b/lib/S3FileSystem.js
@@ -43,31 +43,40 @@ class S3FileSystem {
     /**
      * Put object data to S3 bucket
      *
-     * @param String bucket
-     * @param String key
-     * @param Buffer buffer
+     * @param ImageData image
      * @return Promise
      */
     putObject(image) {
-        return new Promise((resolve, reject) => {
-            const params = {
-                Bucket:       image.bucketName,
-                Key:          image.fileName,
-                Body:         image.data,
-                Metadata:     { "img-processed": "true" },
-                ContentType:  image.headers.ContentType,
-                CacheControl: image.headers.CacheControl,
-                ACL:          image.acl || "private"
-            };
+        const params = {
+            Bucket:       image.bucketName,
+            Key:          image.fileName,
+            Body:         image.data,
+            Metadata:     { "img-processed": "true" },
+            ContentType:  image.headers.ContentType,
+            CacheControl: image.headers.CacheControl,
+            ACL:          image.acl || "private"
+        };
 
-            console.log("Uploading to: " + params.Key + " (" + params.Body.length + " bytes)");
+        console.log("Uploading to: " + params.Key + " (" + params.Body.length + " bytes)");
 
-            this.client.putObject(params).promise().then((data) => {
-                resolve("S3 putObject success");
-            }).catch((err) => {
-                reject(err);
-            });
-        });
+        return this.client.putObject(params).promise();
+    }
+
+    /**
+     * Delete object data from S3 bucket
+     *
+     * @param ImageData image
+     * @return Promise
+     */
+    deleteObject(image) {
+        const params = {
+            Bucket: image.bucketName,
+            Key:    image.fileName
+        };
+
+        console.log("Delete original object: " + params.Key);
+
+        return this.client.deleteObject(params).promise();
     }
 }
 

--- a/test/s3-file-system.js
+++ b/test/s3-file-system.js
@@ -100,7 +100,7 @@ test("Fail on network error while pushing ImageData object to S3", async t => {
     })
 });
 
-test("Delate valid ImageData object from S3", async t => {
+test("Delete valid ImageData object from S3", async t => {
     const image = new ImageData("regular.jpg", "fixture", fixture, {}, "private");
 
     fileSystem.deleteObject(image).then(() => t.pass());


### PR DESCRIPTION
Implement for https://github.com/ysugimoto/aws-lambda-image/issues/133

Added `move` option for `backup` configuration.
If `move: true`, original file will delete from Bucket after processes completed.

And I refactored some:

- `S3FileSystem` returns `Promise` directory because return value won't use anywhere
- Ignore lint for `node_modules/`