### PR TITLE
Implement override optmizers arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ It's copy of our example file `config.json.sample`. More or less it looks like:
 |               |      prefix     |  String | Prepend filename prefix if supplied.                                                                                                      |
 |               |      suffix     |  String | Append filename suffix if supplied.                                                                                                       |
 |               |       acl       |  String | Permission of S3 object. [See AWS ACL documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property).  |
+|   optimizer   |        -        |  Object | Define argument pass to the each Optimizers.                                                                                              |
+|               |     pngquant    |  Array  | `Pngqunat` command arguments. Default is `["--speed=1", "256"]`.                                                                          |
+|               |    jpegoptim    |  Array  | `Jpegoptim` command arguments. Default is `["-s", "--all-progressive"]`.                                                                  |
+|               |     mozjpeg     |  Array  | `Mozjpeg` command arguments. Default is `["-optimize", "-progressive"]`.                                                                  |
+|               |     gifsicle    |  Array  | `Gifsicle` command arguments. Default is `["--optimize"]`.                                                                                |
+
+Note that the `optmizer` option will **force** override its command arguments, so if you define these configurations, we don't care any more about how optimizer works.
 
 ### Testing Configuration
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ It's copy of our example file `config.json.sample`. More or less it looks like:
 |               |      prefix     |  String | Prepend filename prefix if supplied.                                                                                                      |
 |               |      suffix     |  String | Append filename suffix if supplied.                                                                                                       |
 |               |       acl       |  String | Permission of S3 object. [See AWS ACL documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property).  |
-|               |       move      | Boolean | If `true`, an original uploaded file will delete from Bucket after completion.                                                              |
+|               |       move      | Boolean | If `true`, an original uploaded file will delete from Bucket after completion.                                                            |
 |    reduce     |        -        |  Object | Reduce setting following fields.                                                                                                          |
 |               |     quality     |  Number | Determine reduced image quality ( only `JPG` ).                                                                                           |
 |               |  jpegOptimizer  |  String | Determine optimiser that should be used `mozjpeg` (default) or `jpegoptim` ( only `JPG` ).                                                |
@@ -113,13 +113,13 @@ It's copy of our example file `config.json.sample`. More or less it looks like:
 |               |      prefix     |  String | Prepend filename prefix if supplied.                                                                                                      |
 |               |      suffix     |  String | Append filename suffix if supplied.                                                                                                       |
 |               |       acl       |  String | Permission of S3 object. [See AWS ACL documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property).  |
-|   optimizer   |        -        |  Object | Define argument pass to the each Optimizers.                                                                                              |
-|               |     pngquant    |  Array  | `Pngqunat` command arguments. Default is `["--speed=1", "256"]`.                                                                          |
+|   optimizers  |        -        |  Object | Definitions for override the each Optimizers command arguments.                                                                           |
+|               |     pngquant    |  Array  | `Pngquant` command arguments. Default is `["--speed=1", "256"]`.                                                                          |
 |               |    jpegoptim    |  Array  | `Jpegoptim` command arguments. Default is `["-s", "--all-progressive"]`.                                                                  |
 |               |     mozjpeg     |  Array  | `Mozjpeg` command arguments. Default is `["-optimize", "-progressive"]`.                                                                  |
 |               |     gifsicle    |  Array  | `Gifsicle` command arguments. Default is `["--optimize"]`.                                                                                |
 
-Note that the `optmizer` option will **force** override its command arguments, so if you define these configurations, we don't care any more about how optimizer works.
+Note that the `optmizers` option will **force** override its command arguments, so if you define these configurations, we don't care any more about how optimizer works.
 
 ### Testing Configuration
 

--- a/bin/configtest
+++ b/bin/configtest
@@ -122,8 +122,7 @@ var reset   = '\u001b[0m';
     }
 
     function formatArray(ary) {
-        ary = ary.map(function(v) { return "\"" + v + "\""; });
-        return "[" + ary.join(", ") + "]";
+        return `[${ary.map(function(v) { return "\"" + v + "\""; }).join(", ")}]`;
     }
 
     function validateSize(stdout, size) {

--- a/bin/configtest
+++ b/bin/configtest
@@ -51,6 +51,15 @@ var reset   = '\u001b[0m';
     var acl = config.acl;
     stdout.write(magenta + "Global S3 ACL:        " + reset + (acl || "Not set") + "\r\n");
 
+    var optimizer = config.optimizers || {};
+    stdout.write("\r\n");
+    stdout.write("Override Optimizer configuration\r\n");
+    stdout.write("--------------------------------\r\n");
+    stdout.write(magenta + "    pngquant  :  " + reset + (optimizer.pngquant  ? formatArray(optimizer.pngquant)  : "Not set") + "\r\n");
+    stdout.write(magenta + "    jpegoptim :  " + reset + (optimizer.jpegoptim ? formatArray(optimizer.jpegoptim) : "Not set") + "\r\n");
+    stdout.write(magenta + "    mozjpeg   :  " + reset + (optimizer.mozjpeg   ? formatArray(optimizer.mozjpeg)   : "Not set") + "\r\n");
+    stdout.write(magenta + "    gifsicle  :  " + reset + (optimizer.gifsicle  ? formatArray(optimizer.gifsocle)  : "Not set") + "\r\n");
+
     stdout.write("\r\n");
     stdout.write("Backup image configuration\r\n");
     stdout.write("--------------------------------\r\n");
@@ -110,6 +119,11 @@ var reset   = '\u001b[0m';
     }
     if (fatals.length !== 0) {
         process.exit(1);
+    }
+
+    function formatArray(ary) {
+        ary = ary.map(function(v) { return "\"" + v + "\""; });
+        return "[" + ary.join(", ") + "]";
     }
 
     function validateSize(stdout, size) {

--- a/bin/configtest
+++ b/bin/configtest
@@ -122,8 +122,7 @@ var reset   = '\u001b[0m';
     }
 
     function formatArray(ary) {
-        ary = ary.map(function(v) { return "\"" + v + "\""; });
-        return "[" + ary.join(", ") + "]";
+        return `[${ary.map(v => `"${v}"`).join(", ")}]`;
     }
 
     function validateSize(stdout, size) {

--- a/bin/configtest
+++ b/bin/configtest
@@ -122,7 +122,8 @@ var reset   = '\u001b[0m';
     }
 
     function formatArray(ary) {
-        return `[${ary.map(function(v) { return "\"" + v + "\""; }).join(", ")}]`;
+        ary = ary.map(function(v) { return "\"" + v + "\""; });
+        return "[" + ary.join(", ") + "]";
     }
 
     function validateSize(stdout, size) {

--- a/lib/ImageProcessor.js
+++ b/lib/ImageProcessor.js
@@ -50,6 +50,7 @@ class ImageProcessor {
         const acl = config.get("acl");
         const bucket = config.get("bucket");
         const jpegOptimizer = config.get("jpegOptimizer", "mozjpeg");
+        const optimizerOptions = config.get("optimizers", {});
 
         let promise = Promise.resolve();
         let processedImages = 0;
@@ -71,6 +72,7 @@ class ImageProcessor {
             reduce.acl = reduce.acl || acl;
             reduce.bucket = reduce.bucket || bucket;
             reduce.jpegOptimizer = reduce.jpegOptimizer || jpegOptimizer;
+            reduce.optimizerOptions = optimizerOptions;
 
             promise = promise
               .then(() => this.execReduceImage(reduce, imageData))
@@ -85,6 +87,7 @@ class ImageProcessor {
             resize.acl = resize.acl || acl;
             resize.bucket = resize.bucket || bucket;
             resize.jpegOptimizer = resize.jpegOptimizer || jpegOptimizer;
+            resize.optimizerOptions = optimizerOptions;
 
             promise = promise
               .then(() => this.execResizeImage(resize, imageData))

--- a/lib/ImageReducer.js
+++ b/lib/ImageReducer.js
@@ -62,22 +62,23 @@ class ImageReducer {
      */
     createReduceProcessList(type) {
         console.log("Reducing to: " + (this.option.directory || "in-place"));
+        const args = this.option.optimizerOptions || {};
 
         const streams = [];
         switch ( type ) {
             case "png":
-                streams.push(new Pngquant());
+                streams.push(new Pngquant(args.pngquant));
                 break;
             case "jpg":
             case "jpeg":
                 if ( this.option.jpegOptimizer === "jpegoptim" ) { // using jpegoptim
-                    streams.push( new JpegOptim( this.option.quality ) );
+                    streams.push(new JpegOptim(this.option.quality, args.jpegoptim));
                 } else {                                           // using mozjpeg
-                    streams.push( new Mozjpeg( this.option.quality ) );
+                    streams.push(new Mozjpeg(this.option.quality, args.mozjpeg) );
                 }
                 break;
             case "gif":
-                streams.push(new Gifsicle());
+                streams.push(new Gifsicle(args.gifsicle));
                 break;
             default:
                 throw new Error("Unexpected output type: " + type);

--- a/lib/optimizer/Gifsicle.js
+++ b/lib/optimizer/Gifsicle.js
@@ -8,12 +8,13 @@ class Gifsicle extends Optimizer {
      *
      * @constructor
      * @extends Optimizer
+     * @param Array|undefined args
      */
-    constructor() {
+    constructor(args) {
         super();
 
         this.command = this.findBin("gifsicle");
-        this.args    = ["--optimize"];
+        this.args    = args || ["--optimize"];
     }
 }
 

--- a/lib/optimizer/Gifsicle.js
+++ b/lib/optimizer/Gifsicle.js
@@ -10,11 +10,11 @@ class Gifsicle extends Optimizer {
      * @extends Optimizer
      * @param Array|undefined args
      */
-    constructor(args) {
+    constructor(args = ["--optimize"]) {
         super();
 
         this.command = this.findBin("gifsicle");
-        this.args    = args || ["--optimize"];
+        this.args    = args;;
     }
 }
 

--- a/lib/optimizer/Gifsicle.js
+++ b/lib/optimizer/Gifsicle.js
@@ -14,7 +14,7 @@ class Gifsicle extends Optimizer {
         super();
 
         this.command = this.findBin("gifsicle");
-        this.args    = args;;
+        this.args    = args;
     }
 }
 

--- a/lib/optimizer/Gifsicle.js
+++ b/lib/optimizer/Gifsicle.js
@@ -10,11 +10,11 @@ class Gifsicle extends Optimizer {
      * @extends Optimizer
      * @param Array|undefined args
      */
-    constructor(args = ["--optimize"]) {
+    constructor(args) {
         super();
 
         this.command = this.findBin("gifsicle");
-        this.args    = args;
+        this.args    = args || ["--optimize"];
     }
 }
 

--- a/lib/optimizer/JpegOptim.js
+++ b/lib/optimizer/JpegOptim.js
@@ -9,17 +9,25 @@ class Jpegoptim extends Optimizer {
      * @constructor
      * @extends Optimizer
      * @param Number|undefined quality
+     * @param Array|undefined args
      */
-    constructor(quality) {
+    constructor(quality, args) {
         super();
 
         this.command = this.findBin("jpegoptim");
-        this.args    = ["--stdin", "-s", "--all-progressive", "--stdout"];
+        this.args    = args || ["-s", "--all-progressive"];
 
         // determine quality if supplied
         if ( quality ) {
             this.args.unshift(quality);
             this.args.unshift("-m");
+        }
+
+        if ( this.args.indexOf("--stdin") === -1 ) {
+            this.args.unshift("--stdin");
+        }
+        if ( this.args.indexOf("--stdout") === -1 ) {
+            this.args.push("--stdout");
         }
     }
 }

--- a/lib/optimizer/JpegOptim.js
+++ b/lib/optimizer/JpegOptim.js
@@ -11,11 +11,11 @@ class Jpegoptim extends Optimizer {
      * @param Number|undefined quality
      * @param Array|undefined args
      */
-    constructor(quality, args) {
+    constructor(quality, args = ["-s", "--all-progressive"]) {
         super();
 
         this.command = this.findBin("jpegoptim");
-        this.args    = args || ["-s", "--all-progressive"];
+        this.args    = args;
 
         // determine quality if supplied
         if ( quality ) {

--- a/lib/optimizer/JpegOptim.js
+++ b/lib/optimizer/JpegOptim.js
@@ -11,11 +11,11 @@ class Jpegoptim extends Optimizer {
      * @param Number|undefined quality
      * @param Array|undefined args
      */
-    constructor(quality, args = ["-s", "--all-progressive"]) {
+    constructor(quality, args) {
         super();
 
         this.command = this.findBin("jpegoptim");
-        this.args    = args;
+        this.args    = args || ["-s", "--all-progressive"];
 
         // determine quality if supplied
         if ( quality ) {

--- a/lib/optimizer/Mozjpeg.js
+++ b/lib/optimizer/Mozjpeg.js
@@ -11,11 +11,11 @@ class Mozjpeg extends Optimizer {
      * @param Number|undefined quality
      * @param Array|undefined args
      */
-    constructor(quality, args = ["-optimize", "-progressive"]) {
+    constructor(quality, args) {
         super();
 
         this.command = this.findBin("cjpeg");
-        this.args    = args;
+        this.args    = args || ["-optimize", "-progressive"];
 
         // determine quality if supplied
         if ( quality ) {

--- a/lib/optimizer/Mozjpeg.js
+++ b/lib/optimizer/Mozjpeg.js
@@ -11,11 +11,11 @@ class Mozjpeg extends Optimizer {
      * @param Number|undefined quality
      * @param Array|undefined args
      */
-    constructor(quality, args) {
+    constructor(quality, args = ["-optimize", "-progressive"]) {
         super();
 
         this.command = this.findBin("cjpeg");
-        this.args    = args || ["-optimize", "-progressive"];
+        this.args    = args;
 
         // determine quality if supplied
         if ( quality ) {

--- a/lib/optimizer/Mozjpeg.js
+++ b/lib/optimizer/Mozjpeg.js
@@ -9,12 +9,13 @@ class Mozjpeg extends Optimizer {
      * @constructor
      * @extends Optimizer
      * @param Number|undefined quality
+     * @param Array|undefined args
      */
-    constructor(quality) {
+    constructor(quality, args) {
         super();
 
         this.command = this.findBin("cjpeg");
-        this.args    = ["-optimize", "-progressive"];
+        this.args    = args || ["-optimize", "-progressive"];
 
         // determine quality if supplied
         if ( quality ) {

--- a/lib/optimizer/Pngquant.js
+++ b/lib/optimizer/Pngquant.js
@@ -11,11 +11,11 @@ class Pngquant extends Optimizer {
      * @extends Optimizer
      * @param Array|undefined args
      */
-    constructor(args) {
+    constructor(args = ["--speed=1", "256"]) {
         super();
 
         this.command = this.findBin("pngquant");
-        this.args    = args || ["--speed=1", "256"];
+        this.args    = args;
 
         if ( this.args.indexOf("-") === -1 ) {
             this.args.push("-");

--- a/lib/optimizer/Pngquant.js
+++ b/lib/optimizer/Pngquant.js
@@ -9,12 +9,17 @@ class Pngquant extends Optimizer {
      *
      * @constructor
      * @extends Optimizer
+     * @param Array|undefined args
      */
-    constructor() {
+    constructor(args) {
         super();
 
         this.command = this.findBin("pngquant");
-        this.args    = ["--speed=1", "256", "-"];
+        this.args    = args || ["--speed=1", "256"];
+
+        if ( this.args.indexOf("-") === -1 ) {
+            this.args.push("-");
+        } 
     }
 }
 

--- a/lib/optimizer/Pngquant.js
+++ b/lib/optimizer/Pngquant.js
@@ -11,11 +11,11 @@ class Pngquant extends Optimizer {
      * @extends Optimizer
      * @param Array|undefined args
      */
-    constructor(args = ["--speed=1", "256"]) {
+    constructor(args) {
         super();
 
         this.command = this.findBin("pngquant");
-        this.args    = args;
+        this.args    = args || ["--speed=1", "256"];
 
         if ( this.args.indexOf("-") === -1 ) {
             this.args.push("-");

--- a/test/optimizer.js
+++ b/test/optimizer.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const Pngquant  = require("../lib/optimizer/Pngquant");
+const Jpegoptim = require("../lib/optimizer/JpegOptim");
+const Mozjpeg   = require("../lib/optimizer/Mozjpeg");
+const Gifsicle  = require("../lib/optimizer/Gifsicle");
+const test      = require("ava");
+
+test("Pngquant accepts override arguments", async t => {
+  const pngquant = new Pngquant(["--lorem", "--ipsum"]);
+
+  t.is(pngquant.args[0], "--lorem");
+  t.is(pngquant.args[1], "--ipsum");
+  // Override, but stdout argument must be exists
+  t.is(pngquant.args[2], "-");
+});
+
+test("Jpegoptim accepts override arguments", async t => {
+  const jpegoptim = new Jpegoptim(90, ["--lorem", "--ipsum"]);
+
+  // Override, but stdin argument must be exists
+  t.is(jpegoptim.args[0], "--stdin");
+  t.is(jpegoptim.args[1], "-m");
+  t.is(jpegoptim.args[2], 90);
+  t.is(jpegoptim.args[3], "--lorem");
+  t.is(jpegoptim.args[4], "--ipsum");
+  t.is(jpegoptim.args[5], "--stdout");
+});
+
+test("Mozjpeg accepts override arguments", async t => {
+  const mozjpeg = new Mozjpeg(90, ["--lorem", "--ipsum"]);
+
+  // Override, but stdin argument must be exists
+  t.is(mozjpeg.args[0], "-quality");
+  t.is(mozjpeg.args[1], 90);
+  t.is(mozjpeg.args[2], "--lorem");
+  t.is(mozjpeg.args[3], "--ipsum");
+});
+
+test("Gifsicle accepts override arguments", async t => {
+  const gifsicle = new Gifsicle(["--lorem", "--ipsum"]);
+
+  // Override, but stdin argument must be exists
+  t.is(gifsicle.args[0], "--lorem");
+  t.is(gifsicle.args[1], "--ipsum");
+});


### PR DESCRIPTION
This PR will be enable to override each optimizers command arguments from https://github.com/ysugimoto/aws-lambda-image/issues/134.

I had planed that adding `optimizers` configuration key, and if exists, override command arguments.
However, we should care about each optimizers have to work with stdin/stdout mode, so I complement argument as much as possible.