### PR TITLE
Bump support and test versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
+  - '8.10'
   - '6.10'
-  - '4.3.2'
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ put on AWS S3 bucket, this package will resize/reduce it and put to S3.
 
 ## Requirements
 
-- Node.js ( AWS Lambda working version is **6.10** )
+- Node.js ( AWS Lambda supports versions of **6.10** and **8.10** )
 
 ## Preparation
 


### PR DESCRIPTION
This PR will notify that this project recommends using node `6.10` or `8.10` because `4.3` has been EOL on April 30, 2018.