### PR TITLE
Preserve User-Defined Metadata

### DIFF
--- a/lib/S3FileSystem.js
+++ b/lib/S3FileSystem.js
@@ -30,7 +30,7 @@ class S3FileSystem {
                         key,
                         bucket,
                         data.Body,
-                        { ContentType: data.ContentType, CacheControl: data.CacheControl },
+                        { ContentType: data.ContentType, CacheControl: data.CacheControl, Metadata: data.Metadata },
                         acl
                     ));
                 }
@@ -51,7 +51,7 @@ class S3FileSystem {
             Bucket:       image.bucketName,
             Key:          image.fileName,
             Body:         image.data,
-            Metadata:     { "img-processed": "true" },
+            Metadata:     Object.assign({}, image.headers.Metadata, { "img-processed": "true" }),
             ContentType:  image.headers.ContentType,
             CacheControl: (options.cacheControl !== undefined) ? options.cacheControl : image.headers.CacheControl,
             ACL:          image.acl || "private"


### PR DESCRIPTION
### Purpose
Preserve [User-Defined Metadata](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-metadata) assigned to the object.

> When uploading an object, you can also assign metadata to the object. You provide this optional information as a name-value (key-value) pair when you send a PUT or POST request to create the object.

Object Metadata
https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-metadata

### Issue Related
#19 

## Use Case
- Currently, this line ```Metadata:     { "img-processed": "true" },``` it's replacing all metadata of the object.
https://github.com/ysugimoto/aws-lambda-image/blob/master/lib/S3FileSystem.js#L54

![screen shot 2018-07-22 at 23 43 26](https://user-images.githubusercontent.com/41435/43054670-0e02a7e4-8e09-11e8-881d-85e1789bb121.png)

- Expected, keep the metadata assigned to the object.

![screen shot 2018-07-22 at 23 41 00](https://user-images.githubusercontent.com/41435/43054629-d5e54e20-8e08-11e8-9ce7-8b242719670b.png)
