### PR TITLE
Enable to switch function name and execution role

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,12 @@ npm config set aws-lambda-image:profile default
 npm config set aws-lambda-image:region eu-west-1
 npm config set aws-lambda-image:memory 1280
 npm config set aws-lambda-image:timeout 5
+npm config set aws-lambda-image:name lambda-function-name
+npm config set aws-lambda-image:role lambda-execution-role
 ```
+
+Note that `aws-lambda-image:name` and `aws-lambda-image:role` are optional.
+If you want to change lambda function name or execution role, type above commands before deploy.
 
 ### Deployment
 

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "profile": "default",
     "region": "eu-west-1",
     "memory": "1280",
-    "timeout": "5"
+    "timeout": "5",
+    "name": "",
+    "role": ""
   },
   "scripts": {
     "postinstall": "[ -f config.json ] || cp config.json.sample config.json",
-    "deploy": "claudia create --profile $npm_package_config_profile --region $npm_package_config_region --version dev --handler index.handler --no-optional-dependencies --timeout $npm_package_config_timeout --memory $npm_package_config_memory --policies policies/*.json",
+    "deploy": "claudia create --profile $npm_package_config_profile $([ \"$npm_package_config_role\" != '' ] && echo \"--role $npm_package_config_role\" || echo \"\") $([ \"$npm_package_config_name\" != '' ] && echo \"--name $npm_package_config_name\" || echo \"\") --region $npm_package_config_region --version dev --handler index.handler --no-optional-dependencies --timeout $npm_package_config_timeout --memory $npm_package_config_memory --policies policies/*.json",
     "add-handler": "npm run add-s3-handler",
     "add-s3-handler": "claudia add-s3-event-source --profile $npm_package_config_profile --bucket $npm_config_s3_bucket --events s3:ObjectCreated:* --prefix $npm_config_s3_prefix --suffix $npm_config_s3_suffix",
     "add-sns-handler": "claudia add-sns-event-source --profile $npm_package_config_profile --topic $npm_config_sns_topic",


### PR DESCRIPTION
Related https://github.com/ysugimoto/aws-lambda-image/issues/170

I thought it is useful for enabling to change lambda function name and function execution role, so I defined more `npm config` parameters:

- `npm config set aws-lamba-image:name [function name]`
- `npm config set aws-lambda-image:role [execution role]`

`claudia` accepts above options `--role` and `--name` as optional, but cannot empty if provide.
So I modified `npm run deploy` script with some `if` condition at inline.

The script becomes complicated I think, so I'm thinking about to write as node script in `bin/deploy` for example. How do you think about it? 