### PR TITLE
Documentation fix - referenced layer key

### DIFF
--- a/doc/LAYERS.md
+++ b/doc/LAYERS.md
@@ -28,7 +28,7 @@ Copy the _arn_ and put it to this project `package.json` config:
 {
     ...
     "config": {
-        "layers": "<put arn here>"
+        "layer": "<put arn here>"
     },
     ...
 }


### PR DESCRIPTION
In the documentation of the layers the key in the config section of the `package.json` is wrong.