### PR TITLE
Use original lambda layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 aws-lambda-image.zip
+aws-lambda-image-layer.zip
 build/
 config.json
 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - '8.10'
   - '10.15'
+  - '12.13'
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ From `nodejs10.x`, AWS Lambda doesn't bundle `ImageMagick` and image related lib
 
 https://forums.aws.amazon.com/thread.jspa?messageID=906619&tstart=0
 
-Therefore, if you'd deploy with `nodejs10.x` runtime (but we prefer and default as it), you need to install AWS Lambda Layer with this function.
-See [LAYERS](https://github.com/ysugimoto/aws-lambda-image/blob/master/doc/LAYERS.md) for instructions.
+Therefore, if you'd deploy with `nodejs10.x` runtime (but we prefer and default as it), it needs to install AWS Lambda Layer with this function.
+This project can support it automatically, see [LAYERS](https://github.com/ysugimoto/aws-lambda-image/blob/master/doc/LAYERS.md) in detail.
 
 ## Preparation
 

--- a/doc/LAYERS.md
+++ b/doc/LAYERS.md
@@ -1,37 +1,44 @@
 # AWS Lambda Layer Configuration
 
-Since node10.x runtime, no longer `ImageMagick` is bundled on runtime. Therefore we can use it by using Lambda Layer.
+Since node10.x runtime, no longer `ImageMagick` is bundled on runtime. Therefore we need use Lambda Layer to enable it.
 
-To work this project as well, you need to install a couple of Layers:
+We provides dedicated Lambda Layer which is bundled binaries we need to run correctly,
+and enables it automatically with corresponds your region to deploy.
 
-- `ImageMagick` - https://github.com/serverlesspub/imagemagick-aws-lambda-2
-- `GraphicsMagick` - https://github.com/rpidanny/gm-lambda-layer
-
-ImageMagick Layer is purpose for resizing image, and GraphicsMagick is purpose for redusing image because this layer bundles some image related shared library (e.g libpng, libjpeg, ...).
-
-## Installation
-
-You can deploy ImageMagick Lambda Layer via `https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:145266761615:applications~image-magick-lambda-layer` which publicly used.
-
-[image]
-
-Press the `Deploy` button and deploy ImageMagick layer, then **make sure deployment region which you're going to deploy is the same as Lambda function**. For instance, if you're going to deploy function onto `eu-west-1`, then this layer also should be deployed on `eu-west-1`.
-
-After finished to deploy, you can see Layer arn of layer via `Layers` menu:
-
-[image]
-
-Copy the _arn_ and put it to this project `package.json` config:
+Then you need to define region to deploy function in `package.json`:
 
 ```json
 # package.json
 {
     ...
     "config": {
-        "layers": "<put arn here>"
+        "region": "<put region here>"
     },
     ...
 }
+```
 
-Thats' all. When you run `npm run deploy` or other deploy command, the installed layer will be applied. The GraphicsMagick layer has already in some developper's layer so we'll apply automatically correspond to your region.
+When you run `npm run deploy` or other deploy command, pre-deployed layer will be applied automatically with your regions.
 
+## Support regions
+
+Now we're supporting following regions:
+
+- ap-northeast-1
+- ap-northeast-2
+- ap-south-1
+- ap-southeast-1
+- ap-southeast-2
+- ca-central-1
+- eu-north-1
+- eu-central-1
+- eu-west-1
+- eu-west-2
+- eu-west-3
+- sa-east-1
+- us-east-1
+- us-east-2
+- us-west-1
+- us-west-2
+
+If you want to use in other regions, please contact us by creating an issue.

--- a/layers/Dockerfile
+++ b/layers/Dockerfile
@@ -1,0 +1,69 @@
+FROM lambci/lambda-base:build
+
+ARG GM_VERSION="1.3.31"
+ARG IMAGICK_VERSION="7.0.8-45"
+
+RUN yum update -y
+
+RUN yum install -y \
+    libpng-devel \
+    libjpeg-devel \
+    libtiff-devel \
+    libuuid-devel \
+    libopenjp2-devel \
+    libtiff-devel \
+    libwebp-devel \
+    libbz-devel \
+    gcc
+
+RUN curl -L https://github.com/ImageMagick/ImageMagick/archive/${IMAGICK_VERSION}.tar.gz -o ImageMagick-${IMAGICK_VERSION}.tar.gz && \
+    tar xfz ImageMagick-${IMAGICK_VERSION}.tar.gz && \
+    cd ImageMagick-${IMAGICK_VERSION} && \
+    ./configure \
+        --disable-dependency-tracking \
+        --disable-shared \
+        --enable-static \
+        --prefix=/opt \
+        --enable-delegate-build \
+        --without-modules \
+        --disable-docs \
+        --without-magick-plus-plus \
+        --without-perl \
+        --without-x \
+        --disable-openmp && \
+    make all && \
+    make install
+
+RUN curl https://versaweb.dl.sourceforge.net/project/graphicsmagick/graphicsmagick/${GM_VERSION}/GraphicsMagick-${GM_VERSION}.tar.xz | tar -xJ && \
+  cd GraphicsMagick-${GM_VERSION} && \
+  ./configure --prefix=/opt --enable-shared=no --enable-static=yes --with-gs-font-dir=/opt/share/fonts/default/Type1 && \
+  make && \
+  make install
+
+RUN cp /usr/lib64/liblcms2.so* /opt/lib && \
+  cp /usr/lib64/libtiff.so* /opt/lib && \
+  cp /usr/lib64/libfreetype.so* /opt/lib && \
+  cp /usr/lib64/libjpeg.so* /opt/lib && \
+  cp /usr/lib64/libpng*.so* /opt/lib && \
+  cp /usr/lib64/libXext.so* /opt/lib && \
+  cp /usr/lib64/libSM.so* /opt/lib && \
+  cp /usr/lib64/libICE.so* /opt/lib && \
+  cp /usr/lib64/libX11.so* /opt/lib && \
+  cp /usr/lib64/liblzma.so* /opt/lib && \
+  cp /usr/lib64/libxml2.so* /opt/lib && \
+  cp /usr/lib64/libgomp.so* /opt/lib && \
+  cp /usr/lib64/libjbig.so* /opt/lib && \
+  cp /usr/lib64/libxcb.so* /opt/lib && \
+  cp /usr/lib64/libXau.so* /opt/lib && \
+  cp /usr/lib64/libfontconfig.so* /opt/lib && \
+  cp /usr/lib64/libwebp.so* /opt/lib && \
+  cp /usr/lib64/libuuid.so /opt/lib/libuuid.so.1 && \
+  cp /usr/lib64/libbz2.so /opt/lib/libbz2.so.1 && \
+  cp /usr/lib64/libexpat.so /opt/lib/libexpat.so.1
+
+RUN mkdir -p /opt/share/fonts/default && \
+  cp -R /usr/share/fonts/default/Type1 /opt/share/fonts/default/Type1
+
+RUN cd /opt && \
+  find . ! -perm -o=r -exec chmod +400 {} \; && \
+  zip -yr /tmp/aws-lambda-image-layer.zip ./*

--- a/layers/build-and-publish.sh
+++ b/layers/build-and-publish.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+docker build -t aws-lambda-image-layer .
+docker run --rm aws-lambda-image-layer cat /tmp/aws-lambda-image-layer.zip > ./aws-lambda-image-layer.zip
+
+REGIONS='
+ap-northeast-1
+ap-northeast-2
+ap-south-1
+ap-southeast-1
+ap-southeast-2
+ca-central-1
+eu-north-1
+eu-central-1
+eu-west-1
+eu-west-2
+eu-west-3
+sa-east-1
+us-east-1
+us-east-2
+us-west-1
+us-west-2
+'
+
+for region in $REGIONS; do
+    version=$(aws lambda publish-layer-version \
+        --region $region \
+        --layer-name aws-lambda-image-layer \
+        --zip-file fileb://aws-lambda-image-layer.zip \
+        --description "bundled binaries layer for aws-lambda-image" \
+        --query Version \
+        --output text)
+
+    aws lambda add-layer-version-permission \
+        --region $region \
+        --layer-name aws-lambda-image-layer \
+        --statement-id aws-lambda-image-layer-sid \
+        --action lambda:GetLayerVersion \
+        --principal '*' \
+        --version-number ${version}
+done

--- a/lib/ImageResizer.js
+++ b/lib/ImageResizer.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const ImageData = require("./ImageData");
-const gm = require("gm").subClass({ imageMagick: true, binPath: "/opt/bin" })
+const gm = require("gm").subClass({ imageMagick: true })
 
 const cropSpec = /(\d+)x(\d+)([+-]\d+)?([+-]\d+)?(%)?/;
 
@@ -66,18 +66,29 @@ class ImageResizer {
                 img = img.setFormat(this.options.format);
             }
 
-            img.toBuffer((err, buffer) => {
-                if (err) {
-                    reject(err);
-                } else {
+            // @see: https://github.com/aheckmann/gm/issues/572#issuecomment-293768810
+            img.stream((err, stdout, stderr) => {
+                if ( err ) {
+                    return reject(err);
+                }
+                const chunks = [];
+                stdout.on('data', (chunk) => {
+                    chunks.push(chunk);
+                });
+                // these are 'once' because they can and do fire multiple times for multiple errors,
+                // but this is a promise so you'll have to deal with them one at a time
+                stdout.once('end', () => {
                     resolve(new ImageData(
                         image.fileName,
                         image.bucketName,
-                        buffer,
+                        Buffer.concat(chunks),
                         image.headers,
                         acl || image.acl
                     ));
-                }
+                });
+                stderr.once('data', (data) => {
+                    reject(String(data));
+                });
             });
         });
     }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "timeout": "5",
     "name": "",
     "role": "",
-    "runtime": "nodejs10.x",
-    "layer": ""
+    "runtime": "nodejs10.x"
   },
   "scripts": {
     "postinstall": "[ -f config.json ] || cp config.json.sample config.json",
@@ -19,7 +18,7 @@
     "add-s3-handler": "claudia add-s3-event-source --profile $npm_package_config_profile --bucket $npm_config_s3_bucket --events s3:ObjectCreated:* --prefix $npm_config_s3_prefix --suffix $npm_config_s3_suffix",
     "add-sns-handler": "claudia add-sns-event-source --profile $npm_package_config_profile --topic $npm_config_sns_topic",
     "release": "claudia set-version --profile $npm_package_config_profile --version production",
-    "update": "$(node scripts/update-arguments.js)",
+    "update": "$(node scripts/update-command.js)",
     "test": "nyc ava",
     "test-config": "./bin/configtest",
     "test-lambda": "claudia test-lambda --profile $npm_package_config_profile --event $npm_config_event_file",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "An AWS Lambda Function to resize/reduce images automatically",
   "config": {
     "profile": "default",
-    "region": "eu-west-1",
+    "region": "ap-northeast-1",
     "memory": "1280",
     "timeout": "5",
-    "name": "",
-    "role": "",
+    "name": "aws-lambda-image-with-dedicated-layer",
+    "role": "lambda_basic_execution",
     "runtime": "nodejs10.x"
   },
   "scripts": {

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,12 +1,33 @@
 const fs = require('fs');
 const path = require('path');
-const DEDICATED_LAYER = "arn:aws:lambda:<REGION>:251217462751:layer:aws-lambda-image-layer:1";
 
 const readPackageConfig = () => {
     const { config } = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json')));
     return config;
 };
+
+const getDedicatedLayerArn = region => {
+    const layerSettingFile = path.join(__dirname, './layers.json');
+    if (!fs.existsSync(layerSettingFile)) {
+        throw new Error("Layer settings file is not found. Abort");
+    }
+    const layerSetting = JSON.parse(fs.readFileSync(layerSettingFile));
+    if (!(region in layerSetting)) {
+        throw new Error(`Layer is not found on region: ${region}`);
+    }
+    return layerSetting[region];
+};
+
+const getRuntimeVersion = runtime => {
+    if (!runtime.indexOf('nodejs') === -1) {
+        throw new Error('Invalid runtime version');
+    }
+    const version = runtime.replace(/nodejs([0-9]+)\..*$/, '$1');
+    return parseInt(version, 10);
+};
+
 module.exports = {
     readPackageConfig,
-    dedicatedLayerArn: DEDICATED_LAYER
+    getDedicatedLayerArn,
+    getRuntimeVersion
 };

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -9,11 +9,13 @@ const readPackageConfig = () => {
 const getDedicatedLayerArn = region => {
     const layerSettingFile = path.join(__dirname, './layers.json');
     if (!fs.existsSync(layerSettingFile)) {
-        throw new Error("Layer settings file is not found. Abort");
+        throw new Error("Layer settings file is not found. Please contact to us: https://github.com/ysugimoto/aws-lambda-image/issues/new");
     }
     const layerSetting = JSON.parse(fs.readFileSync(layerSettingFile));
     if (!(region in layerSetting)) {
-        throw new Error(`Layer is not found on region: ${region}`);
+        throw new Error(
+            `Layer is not found on your region: ${region}. To be enable it, please contact to us with an issue: https://github.com/ysugimoto/aws-lambda-image/issues/new`
+        );
     }
     return layerSetting[region];
 };

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,25 +1,12 @@
 const fs = require('fs');
 const path = require('path');
-const GRAPHICSMAGICK_LAYER = "arn:aws:lambda:<REGION>:175033217214:layer:graphicsmagick:2";
+const DEDICATED_LAYER = "arn:aws:lambda:<REGION>:251217462751:layer:aws-lambda-image-layer:1";
 
 const readPackageConfig = () => {
     const { config } = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json')));
     return config;
 };
-
-const createLambdaLayers = (layer, region) => {
-    const customLayers = layer
-        .split(',')
-        .map(l => l.trim())
-        .filter(l => !!l);
-    // Add GRAPHICSMAGICK_LAYER
-    customLayers.push(
-        GRAPHICSMAGICK_LAYER.replace('<REGION>', region),
-    );
-    return Array.from(new Set(customLayers)).join(',');
-};
-
 module.exports = {
     readPackageConfig,
-    createLambdaLayers
+    dedicatedLayerArn: DEDICATED_LAYER
 };

--- a/scripts/deploy-command.js
+++ b/scripts/deploy-command.js
@@ -1,6 +1,7 @@
 const {
     readPackageConfig,
-    dedicatedLayerArn
+    getDedicatedLayerArn,
+    getRuntimeVersion
 } = require('./common');
 
 const {
@@ -32,9 +33,9 @@ if (role) {
 if (name) {
     claudiaArgs.push(`--name ${name}`);
 }
-// on runtime nodejs10.x, need ImageMagick Layer
-if (runtime.indexOf("nodejs10") !== -1) {
-    claudiaArgs.push(`--layers ${dedicatedLayerArn}`);
+// if runtime is upper than nodejs10.x, need Layer
+if (getRuntimeVersion(runtime) >= 10) {
+    claudiaArgs.push(`--layers ${getDedicatedLayerArn(region)}`);
 }
 
 process.stdout.write(claudiaArgs.join(" "));

--- a/scripts/deploy-command.js
+++ b/scripts/deploy-command.js
@@ -1,6 +1,6 @@
 const {
     readPackageConfig,
-    createLambdaLayers
+    dedicatedLayerArn
 } = require('./common');
 
 const {
@@ -10,20 +10,8 @@ const {
     runtime = "nodejs10.x",
     profile,
     name,
-    role,
-    layer
+    role
 } = readPackageConfig();
-
-// on runtime nodejs10.x, need ImageMagick Layer
-if (runtime.indexOf("nodejs10") !== -1 && layer === "") {
-    console.error(`
-[Deploy function failed!]
-On nodejs10.x runtime, you need to install ImageMagick with AWS Lambda Layer.
-See https://github.com/ysugimoto/aws-lambda-image/blob/master/doc/LAYERS.md of instructions`
-    );
-    // eslint-disable-next-line no-process-exit
-    process.exit(0);
-}
 
 const claudiaCommand = [
     "claudia",
@@ -36,8 +24,7 @@ const claudiaCommand = [
     `--region ${region}`,
     `--timeout ${timeout}`,
     `--memory ${memory}`,
-    `--runtime ${runtime}`,
-    `--layers ${createLambdaLayers(layer, region)}`
+    `--runtime ${runtime}`
 ];
 if (role) {
     claudiaArgs.push(`--role ${role}`);
@@ -45,4 +32,9 @@ if (role) {
 if (name) {
     claudiaArgs.push(`--name ${name}`);
 }
+// on runtime nodejs10.x, need ImageMagick Layer
+if (runtime.indexOf("nodejs10") !== -1) {
+    claudiaArgs.push(`--layers ${dedicatedLayerArn}`);
+}
+
 process.stdout.write(claudiaArgs.join(" "));

--- a/scripts/deploy-command.js
+++ b/scripts/deploy-command.js
@@ -28,14 +28,14 @@ const claudiaCommand = [
     `--runtime ${runtime}`
 ];
 if (role) {
-    claudiaArgs.push(`--role ${role}`);
+    claudiaCommand.push(`--role ${role}`);
 }
 if (name) {
-    claudiaArgs.push(`--name ${name}`);
+    claudiaCommand.push(`--name ${name}`);
 }
 // if runtime is upper than nodejs10.x, need Layer
 if (getRuntimeVersion(runtime) >= 10) {
-    claudiaArgs.push(`--layers ${getDedicatedLayerArn(region)}`);
+    claudiaCommand.push(`--layers ${getDedicatedLayerArn(region)}`);
 }
 
-process.stdout.write(claudiaArgs.join(" "));
+process.stdout.write(claudiaCommand.join(" "));

--- a/scripts/layers.json
+++ b/scripts/layers.json
@@ -1,0 +1,18 @@
+{
+  "ap-northeast-1": "arn:aws:lambda:ap-northeast-1:251217462751:layer:aws-lambda-image-layer:8",
+  "ap-northeast-2": "arn:aws:lambda:ap-northeast-2:251217462751:layer:aws-lambda-image-layer:2",
+  "ap-south-1": "arn:aws:lambda:ap-south-1:251217462751:layer:aws-lambda-image-layer:2",
+  "ap-southeast-1": "arn:aws:lambda:ap-southeast-1:251217462751:layer:aws-lambda-image-layer:2",
+  "ap-southeast-2": "arn:aws:lambda:ap-southeast-2:251217462751:layer:aws-lambda-image-layer:1",
+  "ca-central-1": "arn:aws:lambda:ca-central-1:251217462751:layer:aws-lambda-image-layer:1",
+  "eu-north-1": "arn:aws:lambda:eu-north-1:251217462751:layer:aws-lambda-image-layer:1",
+  "eu-central-1": "arn:aws:lambda:eu-central-1:251217462751:layer:aws-lambda-image-layer:1",
+  "eu-west-1": "arn:aws:lambda:eu-west-1:251217462751:layer:aws-lambda-image-layer:1",
+  "eu-west-2": "arn:aws:lambda:eu-west-2:251217462751:layer:aws-lambda-image-layer:1",
+  "eu-west-3": "arn:aws:lambda:eu-west-3:251217462751:layer:aws-lambda-image-layer:1",
+  "sa-east-1": "arn:aws:lambda:sa-east-1:251217462751:layer:aws-lambda-image-layer:1",
+  "us-east-1": "arn:aws:lambda:us-east-1:251217462751:layer:aws-lambda-image-layer:1",
+  "us-east-2": "arn:aws:lambda:us-east-2:251217462751:layer:aws-lambda-image-layer:1",
+  "us-west-1": "arn:aws:lambda:us-west-1:251217462751:layer:aws-lambda-image-layer:1",
+  "us-west-2": "arn:aws:lambda:us-west-2:251217462751:layer:aws-lambda-image-layer:1"
+}

--- a/scripts/update-command.js
+++ b/scripts/update-command.js
@@ -1,34 +1,20 @@
 const {
     readPackageConfig,
-    createLambdaLayers
+    dedicatedLayerArn
 } = require('./common');
 
-const {
-    region = "eu-west-1",
-    memory = "1280",
-    timeout = "5",
-    runtime = "nodejs10.x",
-    profile,
-    name,
-    role,
-    layer
-} = readPackageConfig();
-
-// on runtime nodejs10.x, need ImageMagick Layer
-if (runtime.indexOf("nodejs10") !== -1 && layer === "") {
-    console.error(`
-[Update function failed!]
-On nodejs10.x runtime, you need to install ImageMagick with AWS Lambda Layer.
-See https://github.com/ysugimoto/aws-lambda-image/blob/master/doc/LAYERS.md of instructions`
-    );
-    // eslint-disable-next-line no-process-exit
-    process.exit(0);
-}
+const { runtime, profile } = readPackageConfig();
 
 const claudiaArgs = [
     "claudia",
     "update",
-    `--profile ${profile}`,
-    `--layers ${createLambdaLayers(layer, region)}`
+    `--profile ${profile}`
 ];
+
+
+// on runtime nodejs10.x, need ImageMagick Layer
+if (runtime.indexOf("nodejs10") !== -1) {
+    claudiaArgs.push(`--layers ${dedicatedLayerArn}`);
+}
+
 process.stdout.write(claudiaArgs.join(" "));

--- a/scripts/update-command.js
+++ b/scripts/update-command.js
@@ -6,7 +6,7 @@ const {
 
 const { runtime, profile, region } = readPackageConfig();
 
-const claudiaArgs = [
+const claudiaCommand = [
     "claudia",
     "update",
     `--profile ${profile}`
@@ -14,7 +14,7 @@ const claudiaArgs = [
 
 // if runtime is upper than nodejs10.x, need Layer
 if (getRuntimeVersion(runtime) >= 10) {
-    claudiaArgs.push(`--layers ${getDedicatedLayerArn(region)}`);
+    claudiaCommand.push(`--layers ${getDedicatedLayerArn(region)}`);
 }
 
-process.stdout.write(claudiaArgs.join(" "));
+process.stdout.write(claudiaCommand.join(" "));

--- a/scripts/update-command.js
+++ b/scripts/update-command.js
@@ -1,9 +1,10 @@
 const {
     readPackageConfig,
-    dedicatedLayerArn
+    getDedicatedLayerArn,
+    getRuntimeVersion
 } = require('./common');
 
-const { runtime, profile } = readPackageConfig();
+const { runtime, profile, region } = readPackageConfig();
 
 const claudiaArgs = [
     "claudia",
@@ -11,10 +12,9 @@ const claudiaArgs = [
     `--profile ${profile}`
 ];
 
-
-// on runtime nodejs10.x, need ImageMagick Layer
-if (runtime.indexOf("nodejs10") !== -1) {
-    claudiaArgs.push(`--layers ${dedicatedLayerArn}`);
+// if runtime is upper than nodejs10.x, need Layer
+if (getRuntimeVersion(runtime) >= 10) {
+    claudiaArgs.push(`--layers ${getDedicatedLayerArn(region)}`);
 }
 
 process.stdout.write(claudiaArgs.join(" "));


### PR DESCRIPTION
This PR changes to use dedicate Lambda Layer wich I deployed to several regions.
By using it, the user doesn't need to consider what layer should use, totally we care about it.

## Layer deployment

See `layers/` directory, I created `Dockerfile` and deploy script. If we need to update layers, we can use it. But layers are deployed on my account, so typically I have to do it :-)

After the layer deployment, it generates `scripts/layers.json` which maps region to current layer versions and use on deploy command.

If you have any concerns, let me know