### PR TITLE
draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ put on AWS S3 bucket, this package will resize/reduce it and put to S3.
 
 From `nodejs10.x`, AWS Lambda doesn't bundle `ImageMagick` and image related libraries.
 
-https://forums.aws.amazon.com/thread.jspa?messageID=906619&tstart=0
+https://forums.aws.amazon.com/thread.jspa?messageID=906619&tstart=0   
 
+If you need a compiled image-magick.zip layer   
+https://connorb-share.s3.eu-west-2.amazonaws.com/image-magick.zip   
+   
+   
 Therefore, if you'd deploy with `nodejs10.x` runtime (but we prefer and default as it), it needs to install AWS Lambda Layer with this function.
 This project can support it automatically, see [LAYERS](https://github.com/ysugimoto/aws-lambda-image/blob/master/doc/LAYERS.md) in detail.
 


### PR DESCRIPTION
not sure I can make this work - the build script fails to spit out aws-lambda image layer.

Dockerfile           build-and-publish.sh
(base) ➜  layers git:(master) ✗ sudo ./build-and-publish.sh
Password:
[+] Building 5.0s (8/11)
 => [internal] load .dockerignore                                                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                                                           0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                      0.0s
 => => transferring dockerfile: 2.39kB                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/lambci/lambda-base:build                                                                                                                                       3.8s
 => [1/8] FROM docker.io/lambci/lambda-base:build@sha256:615b838041fe6cb48d53f15026468dd00baff21d6f97034dda59edd057122277                                                                                 0.0s
 => CACHED [2/8] RUN yum update -y                                                                                                                                                                        0.0s
 => CACHED [3/8] RUN yum install -y     libpng-devel     libjpeg-devel     libtiff-devel     libuuid-devel     libopenjp2-devel     libtiff-devel     libwebp-devel     libbz-devel     gcc               0.0s
 => CACHED [4/8] RUN curl -L https://github.com/ImageMagick/ImageMagick/archive/7.0.8-45.tar.gz -o ImageMagick-7.0.8-45.tar.gz &&     tar xfz ImageMagick-7.0.8-45.tar.gz &&     cd ImageMagick-7.0.8-45  0.0s
 => ERROR [5/8] RUN curl https://versaweb.dl.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.31/GraphicsMagick-1.3.31.tar.xz | tar -xJ &&   cd GraphicsMagick-1.3.31 &&   ./configure --prefix  1.1s
------
 > [5/8] RUN curl https://versaweb.dl.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.31/GraphicsMagick-1.3.31.tar.xz | tar -xJ &&   cd GraphicsMagick-1.3.31 &&   ./configure --prefix=/opt --enable-shared=no --enable-static=yes --with-gs-font-dir=/opt/share/fonts/default/Type1 &&   make &&   make install:
#8 0.182   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#8 0.183                                  Dload  Upload   Total   Spent    Left  Speed
100   154  100   154    0     0    178      0 --:--:-- --:--:-- --:--:--   178
#8 1.048 xz: (stdin): File format not recognized
#8 1.048 tar: Child returned status 1
#8 1.048 tar: Error is not recoverable: exiting now
------
failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c curl https://versaweb.dl.sourceforge.net/project/graphicsmagick/graphicsmagick/${GM_VERSION}/GraphicsMagick-${GM_VERSION}.tar.xz | tar -xJ &&   cd GraphicsMagick-${GM_VERSION} &&   ./configure --prefix=/opt --enable-shared=no --enable-static=yes --with-gs-font-dir=/opt/share/fonts/default/Type1 &&   make &&   make install]: runc did not terminate sucessfully
Unable to find image 'aws-lambda-image-layer:latest' locally
docker: Error response from daemon: pull access denied for aws-lambda-image-layer, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
deploying layer image to ap-south-1

--zip-file must be a zip file with the fileb:// prefix.
Example usage:  --zip-file fileb://path/to/file.zip